### PR TITLE
bind methods that use `this`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -158,7 +158,7 @@ export class SQLFragment<RunResult = pg.QueryResult['rows']> {
    * is piped via `runResultTransform` before being returned.
    * @param queryable A database client or pool
    */
-  async run(queryable: Queryable): Promise<RunResult> {
+  run = async (queryable: Queryable): Promise<RunResult> => {
     const
       query = this.compile(),
       config = getConfig();
@@ -177,7 +177,7 @@ export class SQLFragment<RunResult = pg.QueryResult['rows']> {
    * be passed to the `pg` query function. Arguments are generally only passed when the 
    * function calls itself recursively.
    */
-  compile(result: SQLQuery = { text: '', values: [] }, parentTable?: string, currentColumn?: Column) {
+  compile = (result: SQLQuery = { text: '', values: [] }, parentTable?: string, currentColumn?: Column) => {
     if (this.parentTable) parentTable = this.parentTable;
 
     result.text += this.literals[0];
@@ -188,7 +188,7 @@ export class SQLFragment<RunResult = pg.QueryResult['rows']> {
     return result;
   }
 
-  compileExpression(expression: SQL, result: SQLQuery = { text: '', values: [] }, parentTable?: string, currentColumn?: Column) {
+  compileExpression = (expression: SQL, result: SQLQuery = { text: '', values: [] }, parentTable?: string, currentColumn?: Column) => {
     if (this.parentTable) parentTable = this.parentTable;
 
     if (expression instanceof SQLFragment) {


### PR DESCRIPTION
thanks for releasing this library, its exactly what i've been missing. I hit a problem earlier when `run` was rebound due to way it was run, this ensures `this` is always what you expect