### PR TITLE
Fix postinstall on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "npm run lint && tsc",
     "preversion": "npm run build",
     "postversion": "npm publish",
-    "postinstall": "node -e 'console.warn(`>>> \\u001b[1;33mZapatos was installed or upgraded. Please (re-)run \\u001b[1;32mnpx zapatos\\u001b[1;33m.\\u001b[0m <<<\\n`)'"
+    "postinstall": "node -e \"console.warn(`>>> \\u001b[1;33mZapatos was installed or upgraded. Please (re-)run \\u001b[1;32mnpx zapatos\\u001b[1;33m.\\u001b[0m <<<\\u000a`)\""
   },
   "files": [
     "/dist",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "npm run lint && tsc",
     "preversion": "npm run build",
     "postversion": "npm publish",
-    "postinstall": "node -e \"console.warn(`>>> \\u001b[1;33mZapatos was installed or upgraded. Please (re-)run \\u001b[1;32mnpx zapatos\\u001b[1;33m.\\u001b[0m <<<\\u000a`)\""
+    "postinstall": "node -e \"console.warn('>>> \\u001b[1;33mZapatos was installed or upgraded. Please (re-)run \\u001b[1;32mnpx zapatos\\u001b[1;33m.\\u001b[0m <<<\\u000a')\""
   },
   "files": [
     "/dist",


### PR DESCRIPTION
Running `npx zapatos` on Windows fails, because there are single quotes in the postinstall script which Windows does not interpret the same way a *nix does. Also, the newline was giving me trouble so I escaped it as well.

FWIW, I ran `npm install zapatos --ignore-scripts` and everything worked fine. Looking forward to trying out this library :-)