### PR TITLE
Allow usage of Zapatos from within node_modules

### DIFF
--- a/generate/enums.ts
+++ b/generate/enums.ts
@@ -5,7 +5,7 @@ Released under the MIT licence: see LICENCE file
 */
 
 import * as db from '../src';
-import type * as s from '../schema';
+import type * as s from 'zapatos/schema';
 
 
 export type EnumData = { [k: string]: string[] };

--- a/generate/tables.ts
+++ b/generate/tables.ts
@@ -5,7 +5,7 @@ Released under the MIT licence: see LICENCE file
 */
 
 import * as db from '../src';
-import type * as s from '../schema';
+import type * as s from 'zapatos/schema';
 import { tsTypeForPgType } from './pgTypes';
 import type { EnumData } from './enums';
 

--- a/generate/tsOutput.ts
+++ b/generate/tsOutput.ts
@@ -27,6 +27,8 @@ Copyright (C) 2020 George MacKerron
 Released under the MIT licence: see LICENCE file
 */
 
+declare module 'zapatos/schema' {
+
 import type {
   JSONValue,
   JSONArray,
@@ -38,8 +40,14 @@ import type {
   ColumnValues,
   ParentColumn,
   DefaultType,
-} from "./src/core";
+} from "zapatos";
 
+`;
+};
+
+const footer = () => {
+  return `
+} // end declare module 'zapatos/schema'
 `;
 };
 
@@ -74,7 +82,8 @@ export const tsForConfig = async (config: CompleteConfig) => {
     ts = header() +
       schemaDefs.join('\n\n') +
       `\n\n/* === cross-table types === */\n` +
-      crossTableTypesForTables(allTables);
+      crossTableTypesForTables(allTables) +
+      footer();
 
   await pool.end();
   return ts;

--- a/generate/write.ts
+++ b/generate/write.ts
@@ -6,15 +6,9 @@ Released under the MIT licence: see LICENCE file
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { moduleRoot, finaliseConfig } from './config';
+import { finaliseConfig } from './config';
 import type { Config } from './config';
 import { tsForConfig } from './tsOutput';
-
-
-const recurseNodes = (node: string): string[] =>
-  fs.statSync(node).isFile() ? [node] :
-    fs.readdirSync(node).reduce<string[]>((memo, n) =>
-      memo.concat(recurseNodes(path.join(node, n))), []);
 
 export const generate = async (suppliedConfig: Config) => {
   const
@@ -24,56 +18,19 @@ export const generate = async (suppliedConfig: Config) => {
 
     ts = await tsForConfig(config),
     folderName = 'zapatos',
-    srcName = 'src',
-    licenceName = 'LICENCE',
-    schemaName = 'schema.ts',
+    schemaName = 'schema.d.ts',
     eslintrcName = '.eslintrc.json',
-    root = moduleRoot(),
     folderTargetPath = path.join(config.outDir, folderName),
-
-    srcTargetPath = path.join(folderTargetPath, srcName),
-    srcOriginPath = path.join(root, srcName),
-    srcOriginPathRelative = path.relative(folderTargetPath, srcOriginPath),
-
-    licenceTargetPath = path.join(folderTargetPath, licenceName),
-    licenceOriginPath = path.join(root, licenceName),
-    licenceOriginPathRelative = path.relative(folderTargetPath, licenceOriginPath),
 
     eslintrcTargetPath = path.join(folderTargetPath, eslintrcName),
     schemaTargetPath = path.join(folderTargetPath, schemaName);
 
   if (!fs.existsSync(folderTargetPath)) fs.mkdirSync(folderTargetPath);
 
-  // TODO: deal with the case when we did have mode copy and now have mode symlink or vice versa
-
-  if (config.srcMode === 'symlink') {
-    if (fs.existsSync(srcTargetPath)) fs.unlinkSync(srcTargetPath);
-
-    log(`Creating symlink: ${srcTargetPath} -> ${srcOriginPathRelative}`);
-    fs.symlinkSync(srcOriginPathRelative, srcTargetPath);
-    log(`Creating symlink: ${licenceTargetPath} -> ${licenceOriginPathRelative}`);
-    fs.symlinkSync(licenceOriginPathRelative, licenceTargetPath);
-
-  } else {
-    const srcFiles = recurseNodes(srcOriginPath)
-      .map(p => path.relative(srcOriginPath, p));
-
-    for (const f of srcFiles) {
-      const
-        srcPath = path.join(srcOriginPath, f),
-        targetDirPath = path.join(srcTargetPath, path.dirname(f)),
-        targetPath = path.join(srcTargetPath, f);
-
-      log(`Copying source file to ${targetPath}`);
-      fs.mkdirSync(targetDirPath, { recursive: true });
-      fs.copyFileSync(srcPath, targetPath);
-    }
-    log(`Copying licence file to ${licenceTargetPath}`);
-    fs.copyFileSync(licenceOriginPath, licenceTargetPath);
+  if (!fs.existsSync(eslintrcTargetPath)) {
+    log(`Writing local ESLint config: ${eslintrcTargetPath}`);
+    fs.writeFileSync(eslintrcTargetPath, '{\n  "ignorePatterns": [\n    "*"\n  ]\n}', { flag: 'w' });
   }
-
-  log(`Writing local ESLint config: ${eslintrcTargetPath}`);
-  fs.writeFileSync(eslintrcTargetPath, '{\n  "ignorePatterns": [\n    "*"\n  ]\n}', { flag: 'w' });
 
   log(`Writing generated schema: ${schemaTargetPath}`);
   fs.writeFileSync(schemaTargetPath, ts, { flag: 'w' });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/jawj/zapatos"
   },
   "prepublish": "tsc",
-  "main": "dist/generate",
+  "main": "dist/src",
+  "types": "dist/src/index.d.ts",
   "bin": {
     "zapatos": "dist/generate-schema.js"
   },

--- a/src/core.ts
+++ b/src/core.ts
@@ -13,7 +13,7 @@ import type {
   Whereable,
   Table,
   Column,
-} from '../schema';
+} from 'zapatos/schema';
 
 import { getConfig } from './config';
 

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -20,7 +20,7 @@ import type {
   Whereable,
   Table,
   Column,
-} from '../schema';
+} from 'zapatos/schema';
 
 import {
   AllType,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,15 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "./dist",
     "target": "es2017",
     "module": "CommonJS",
     "strict": true,
     "declaration": true,
+    "paths": {
+      "*": [
+        "typings/*",
+      ],
+    }
   }
 }

--- a/typings/zapatos/schema.d.ts
+++ b/typings/zapatos/schema.d.ts
@@ -13,7 +13,7 @@ import type {
   ColumnValues,
   ParentColumn,
   DefaultType,
-} from "./src";
+} from '../../src';
 
 export namespace pg_indexes {
   export type Table = "pg_indexes";


### PR DESCRIPTION
In the discussion in #16, this is a working approach to allowing Zapatos to be used within node_modules, no copying or symlinking necessary. Some notes on the changes and the approach:

- For Zapatos users (via `npm install zapatos`), this *shouldn't* require a tsconfig change, so long as the generated schema file ends up in a path the project looks for TS files.
- For the Zapatos development, there *is* a `paths` config, it basically mirrors the implicit config for `node_modules`, to allow the internal `schema.d.ts` to be picked up as `zapatos/schema`. This allows replacing the relative path imports with a stable module path `zapatos/schema`. TypeScript does not include this internal `schema.d.ts` in the build, so there will be no ambiguity when users generate their own schema.
- I've removed the copy and symlink code paths in this PR. I understand there may still be use cases for those configurations (the most obvious one which comes to mind, as mentioned in #16, is projects which access multiple databases), but mainly I wanted to keep this simple for easy review.
- A change to `package.json` was necessary: `main` now references `src` rather than `generate`. This is almost certainly a breaking change to the programmatic generation APIs, which I want to call out. I didn't address this mainly because I wanted to make sure to get this PR open before the weekend is out, and I don't feel familiar enough in the codebase yet to attempt to resolve it with confidence.

I manually verified that this worked on a simple local dummy project with the following steps:

1. In Zapatos: `npm run build`. I believe this step can be skipped if you rename `preversion` to `prepack`, but I didn't want to be presumptuous about the build/publish flow.
2. In Zapatos: `npm pack`. This produces a tarball of the build similar to what would be published to NPM.
3. In test database: `CREATE TABLE "TestZapatosNodeModules" ("name" TEXT NOT NULL);`
4. In test project: `npm install ../zapatos/zapatos-0.1.51.tgz`.
5. In test project: `./node_modules/.bin/zapatos`
6. In test project:

    ```typescript
    import * as pg from 'pg';
    import * as db from 'zapatos';
    import * as s  from 'zapatos/schema';

    type Equals<X, Y> =(<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
    type PromiseType<T extends Promise<any>> = T extends Promise<infer U> ? U : never;

    const pool = new pg.Pool({});

    export const testSQL = async () => {
        const [ { name } ] = await db.sql<s.TestZapatosNodeModules.SQL, s.TestZapatosNodeModules.Selectable[]>`
            SELECT * FROM ${"TestZapatosNodeModules"}
        `.run(pool);

        return name;
    };

    const testSQLSuccess: Equals<PromiseType<ReturnType<typeof testSQL>>, string> = true;

    export const testShortcut = async () => {
        const [ { name } ] = await db.select('TestZapatosNodeModules', db.all).run(pool);

        return name;
    };

    const testShortcutSuccess: Equals<PromiseType<ReturnType<typeof testShortcut>>, string> = true;
    ```