### PR TITLE
use `export declare namespace` for babel compatibility

### DIFF
--- a/generate/enums.ts
+++ b/generate/enums.ts
@@ -33,7 +33,7 @@ export const enumTypesForEnumData = (enums: EnumData) => {
   const types = Object.keys(enums)
     .map(name => `
 export type ${name} = ${enums[name].map(v => `'${v}'`).join(' | ')};
-export namespace every {
+export declare namespace every {
   export type ${name} = [${enums[name].map(v => `'${v}'`).join(', ')}];
 }`)
     .join('');

--- a/generate/tables.ts
+++ b/generate/tables.ts
@@ -86,7 +86,7 @@ export const definitionForTableInSchema = async (
     WHERE i.${"tablename"} = ${db.param(tableName)}`.run(pool);
 
   const tableDef = `
-export namespace ${tableName} {
+export declare namespace ${tableName} {
   export type Table = '${tableName}';
   export interface Selectable {
     ${selectables.join('\n    ')}

--- a/schema.ts
+++ b/schema.ts
@@ -15,7 +15,7 @@ import type {
   DefaultType,
 } from "./src";
 
-export namespace pg_indexes {
+export declare namespace pg_indexes {
   export type Table = "pg_indexes";
   export interface Selectable {
     indexname: string;
@@ -31,7 +31,7 @@ export namespace pg_indexes {
   export type SQL = SQLExpression | SQLExpression[];
 }
 
-export namespace pg_class {
+export declare namespace pg_class {
   export type Table = "pg_class";
   export interface Selectable {
     oid: number;
@@ -47,7 +47,7 @@ export namespace pg_class {
   export type SQL = SQLExpression | SQLExpression[];
 }
 
-export namespace pg_index {
+export declare namespace pg_index {
   export type Table = "pg_index";
   export interface Selectable {
     indexrelid: number;
@@ -63,7 +63,7 @@ export namespace pg_index {
   export type SQL = SQLExpression | SQLExpression[];
 }
 
-export namespace pg_type {
+export declare namespace pg_type {
   export type Table = "pg_type";
   export interface Selectable {
     typname: string;
@@ -79,7 +79,7 @@ export namespace pg_type {
   export type SQL = SQLExpression | SQLExpression[];
 }
 
-export namespace pg_enum {
+export declare namespace pg_enum {
   export type Table = "pg_enum";
   export interface Selectable {
     enumtypid: number;
@@ -95,7 +95,7 @@ export namespace pg_enum {
   export type SQL = SQLExpression | SQLExpression[];
 }
 
-export namespace pg_namespace {
+export declare namespace pg_namespace {
   export type Table = "pg_namespace";
   export interface Selectable {
     oid: number;
@@ -111,7 +111,7 @@ export namespace pg_namespace {
   export type SQL = SQLExpression | SQLExpression[];
 }
 
-export namespace information_schema.columns {
+export declare namespace information_schema.columns {
   export type Table = '"information_schema"."columns"';
   export interface Selectable {
     table_name: string;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -26,7 +26,7 @@ export enum Isolation {
   SerializableRODeferrable = "SERIALIZABLE, READ ONLY, DEFERRABLE"
 }
 
-export namespace TxnSatisfying {
+export declare namespace TxnSatisfying {
   export type Serializable = Isolation.Serializable;
   export type RepeatableRead = Serializable | Isolation.RepeatableRead;
   export type ReadCommitted = RepeatableRead | Isolation.ReadCommitted;


### PR DESCRIPTION
babel complains that it can't compile `export namespace` in typescript. It looks like its safe to use declare here as its only exporting types (see https://ostrowski.ninja/typescript-namespaces-cra/ - declare namespace vs namespace).