### PR TITLE
Fix tsc errors in projects that have a strict tsconfig

### DIFF
--- a/generate/tsOutput.ts
+++ b/generate/tsOutput.ts
@@ -30,6 +30,7 @@ Zapatos: https://jawj.github.io/zapatos/
 Copyright (C) 2020 George MacKerron
 Released under the MIT licence: see LICENCE file
 */
+// @ts-nocheck
 
 `;
 };

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -36,6 +36,7 @@ export declare namespace TxnSatisfying {
   export type SerializableRODeferrable = SerializableRO | Isolation.SerializableRODeferrable;
 }
 
+// @ts-ignore
 export interface TxnClient<T extends Isolation> extends pg.PoolClient { }
 
 let txnSeq = 0;


### PR DESCRIPTION
Zapatos produces some errors when building with `tsc` in a project that has strict tsconfig. See the sample output below.

Most of the errors happen because with a simple DB schema, some imports in the generated schema code simply go unused.
Another error happens because the generic type `T` is unused in the `TxnClient` type (which is not in generated code but in copied code).

This PR disables all code checks on the generated schema, and adds a `ts-ignore` flag for the specific warning on `TxnClient`.

```JavaScript
$ tsc
src/zapatos/schema.ts:11:3 - error TS6196: 'JSONValue' is declared but never used.
11   JSONValue,
     ~~~~~~~~~

src/zapatos/schema.ts:12:3 - error TS6196: 'JSONArray' is declared but never used.
12   JSONArray,
     ~~~~~~~~~

src/zapatos/schema.ts:15:3 - error TS6196: 'SQL' is declared but never used.
15   SQL,
     ~~~

src/zapatos/src/transaction.ts:39:27 - error TS6133: 'T' is declared but its value is never read.
39 export interface TxnClient<T extends Isolation> extends pg.PoolClient { }
                             ~~~~~~~~~~~~~~~~~~~~~
```