### PR TITLE
fix circular dependency

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -9,7 +9,7 @@ Released under the MIT licence: see LICENCE file
 
 import type * as pg from 'pg';
 import { getConfig } from './config';
-import { isPOJO, NoInfer } from './utils';
+import { Default, isPOJO, NoInfer } from './utils';
 
 import type {
   Updatable,
@@ -21,10 +21,6 @@ import type {
 
 // === symbols, types, wrapper classes and shortcuts ===
 
-/**
- * Compiles to `DEFAULT` for use in `INSERT`/`UPDATE` queries.
- */
-export const Default = Symbol('DEFAULT');
 export type DefaultType = typeof Default;
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,6 @@ Copyright (C) 2020 George MacKerron
 Released under the MIT licence: see LICENCE file
 */
 
-import { Default } from './core';
-
 export type NoInfer<T> = [T][T extends any ? 0 : never];  // https://github.com/Microsoft/TypeScript/issues/14829
 export type PromisedType<P> = P extends PromiseLike<infer U> ? U : never;
 
@@ -38,6 +36,11 @@ export const mapWithSeparator = <TIn, TSep, TOut>(
   }
   return result;
 };
+
+/**
+ * Compiles to `DEFAULT` for use in `INSERT`/`UPDATE` queries.
+ */
+export const Default = Symbol('DEFAULT');
 
 /**
  * Map an array of objects to an output array by taking the union of all objects' keys


### PR DESCRIPTION
Moved definition of `Default` symbol from core to utils to get rid of circular dependency.