### PR TITLE
WIP: Remove need for copying the core src into consumer repo

### DIFF
--- a/generate/enums.ts
+++ b/generate/enums.ts
@@ -5,7 +5,7 @@ Released under the MIT licence: see LICENCE file
 */
 
 import * as db from '../src';
-import type * as s from '../schema';
+import type * as s from '../typings/zapatos/schema';
 
 
 export type EnumData = { [k: string]: string[] };
@@ -33,7 +33,7 @@ export const enumTypesForEnumData = (enums: EnumData) => {
   const types = Object.keys(enums)
     .map(name => `
 export type ${name} = ${enums[name].map(v => `'${v}'`).join(' | ')};
-export declare namespace every {
+export namespace every {
   export type ${name} = [${enums[name].map(v => `'${v}'`).join(', ')}];
 }`)
     .join('');

--- a/generate/tables.ts
+++ b/generate/tables.ts
@@ -5,7 +5,7 @@ Released under the MIT licence: see LICENCE file
 */
 
 import * as db from '../src';
-import type * as s from '../schema';
+import type * as s from '../typings/zapatos/schema';
 import { tsTypeForPgType } from './pgTypes';
 import type { EnumData } from './enums';
 import type { CustomTypes } from './tsOutput';
@@ -85,8 +85,9 @@ export const definitionForTableInSchema = async (
     WHERE i.${"tablename"} = ${db.param(tableName)}`.run(pool);
 
   const tableDef = `
-export declare namespace ${tableName} {
+export namespace ${tableName} {
   export type Table = '${tableName}';
+  export type Schema = '${schemaName}';
   export interface Selectable {
     ${selectables.join('\n    ')}
   }

--- a/generate/tables.ts
+++ b/generate/tables.ts
@@ -87,7 +87,6 @@ export const definitionForTableInSchema = async (
   const tableDef = `
 export namespace ${tableName} {
   export type Table = '${tableName}';
-  export type Schema = '${schemaName}';
   export interface Selectable {
     ${selectables.join('\n    ')}
   }

--- a/generate/tsOutput.ts
+++ b/generate/tsOutput.ts
@@ -34,7 +34,7 @@ Released under the MIT licence: see LICENCE file
 `;
 };
 
-const coreImports = `import * as db from './src/core';`;
+const coreImports = `import * as db from 'zapatos';`;
 
 const coreDefs = `
 type BasicWhereableFromInsertable<T> = { [K in keyof T]: Exclude<T[K] | db.ParentColumn, null | db.DefaultType> };
@@ -60,7 +60,7 @@ const sourceFilesForCustomTypes = (customTypes: CustomTypes) =>
   Object.fromEntries(Object.entries(customTypes)
     .map(([name, baseType]) => [
       name,
-      `${customTypeHeader}${baseType === 'db.JSONValue' ? "\nimport type * as db from '../src/core';\n" : ""}
+      `${customTypeHeader}${baseType === 'db.JSONValue' ? "\nimport type * as db from 'zapatos';\n" : ""}
 export type ${name} = ${baseType};  // replace with your custom type or interface as desired
 `,
     ]));

--- a/generate/tsOutput.ts
+++ b/generate/tsOutput.ts
@@ -30,8 +30,19 @@ Zapatos: https://jawj.github.io/zapatos/
 Copyright (C) 2020 George MacKerron
 Released under the MIT licence: see LICENCE file
 */
-
 `;
+};
+
+export const declaration = (module: string) => {
+  return `
+declare module '${module}' {
+  `;
+}
+
+export const footer = () => {
+    return `
+} // end declare module
+  `;
 };
 
 const coreImports = `import * as db from 'zapatos';`;
@@ -95,12 +106,14 @@ export const tsForConfig = async (config: CompleteConfig) => {
     allTables = ([] as string[]).concat(...schemaTables).sort(),
     hasCustomTypes = Object.keys(customTypes).length > 0,
     ts = header() +
+      declaration('zapatos/schema') +
       coreImports + '\n' +
-      (hasCustomTypes ? "import * as c from './custom';\n" : '') +
+      (hasCustomTypes ? "import * as c from 'zapatos/custom';\n" : '') +
       coreDefs +
       schemaDefs.join('\n\n') +
       `\n\n/* === cross-table types === */\n` +
-      crossTableTypesForTables(allTables),
+      crossTableTypesForTables(allTables) + 
+      footer(),
     customTypeSourceFiles = sourceFilesForCustomTypes(customTypes);
 
   await pool.end();

--- a/generate/write.ts
+++ b/generate/write.ts
@@ -8,14 +8,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { finaliseConfig } from './config';
 import type { Config } from './config';
-import { tsForConfig, header } from './tsOutput';
+import { tsForConfig, header, footer, declaration } from './tsOutput';
 
 export const customFolderName = 'custom';
-
-const recurseNodes = (node: string): string[] =>
-  fs.statSync(node).isFile() ? [node] :
-    fs.readdirSync(node).reduce<string[]>((memo, n) =>
-      memo.concat(recurseNodes(path.join(node, n))), []);
 
 export const generate = async (suppliedConfig: Config) => {
   const
@@ -55,6 +50,9 @@ export const generate = async (suppliedConfig: Config) => {
         fs.writeFileSync(customTypeFilePath, customTypeFileContent, { flag: 'w' });
       }
     }
+
+    exportsFileContent += declaration('zapatos/custom');
+    exportsFileContent += footer();
 
     const exportsFilePath = path.join(customFolderTargetPath, 'index.ts');
     fs.writeFileSync(exportsFilePath, exportsFileContent, { flag: 'w' });

--- a/generate/write.ts
+++ b/generate/write.ts
@@ -6,7 +6,7 @@ Released under the MIT licence: see LICENCE file
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { moduleRoot, finaliseConfig } from './config';
+import { finaliseConfig } from './config';
 import type { Config } from './config';
 import { tsForConfig, header } from './tsOutput';
 
@@ -27,58 +27,14 @@ export const generate = async (suppliedConfig: Config) => {
 
     { ts, customTypeSourceFiles } = await tsForConfig(config),
     folderName = 'zapatos',
-    srcName = 'src',
-    licenceName = 'LICENCE',
-    schemaName = 'schema.ts',
-    eslintrcName = '.eslintrc.json',
-    root = moduleRoot(),
+    schemaName = 'schema.d.ts',
     folderTargetPath = path.join(config.outDir, folderName),
 
-    srcTargetPath = path.join(folderTargetPath, srcName),
-    srcOriginPath = path.join(root, srcName),
-    srcOriginPathRelative = path.relative(folderTargetPath, srcOriginPath),
-
-    licenceTargetPath = path.join(folderTargetPath, licenceName),
-    licenceOriginPath = path.join(root, licenceName),
-    licenceOriginPathRelative = path.relative(folderTargetPath, licenceOriginPath),
-
-    eslintrcTargetPath = path.join(folderTargetPath, eslintrcName),
     schemaTargetPath = path.join(folderTargetPath, schemaName),
     customFolderTargetPath = path.join(folderTargetPath, customFolderName);
 
-  if (!fs.existsSync(folderTargetPath)) fs.mkdirSync(folderTargetPath);
 
-  // TODO: deal with the case when we did have mode copy and now have mode symlink or vice versa
-
-  if (config.srcMode === 'symlink') {
-    if (fs.existsSync(srcTargetPath)) fs.unlinkSync(srcTargetPath);
-
-    log(`Creating symlink: ${srcTargetPath} -> ${srcOriginPathRelative}`);
-    fs.symlinkSync(srcOriginPathRelative, srcTargetPath);
-    log(`Creating symlink: ${licenceTargetPath} -> ${licenceOriginPathRelative}`);
-    fs.symlinkSync(licenceOriginPathRelative, licenceTargetPath);
-
-  } else {
-    const srcFiles = recurseNodes(srcOriginPath)
-      .map(p => path.relative(srcOriginPath, p));
-
-    for (const f of srcFiles) {
-      const
-        srcPath = path.join(srcOriginPath, f),
-        targetDirPath = path.join(srcTargetPath, path.dirname(f)),
-        targetPath = path.join(srcTargetPath, f);
-
-      log(`Copying source file to ${targetPath}`);
-      fs.mkdirSync(targetDirPath, { recursive: true });
-      fs.copyFileSync(srcPath, targetPath);
-    }
-    log(`Copying licence file to ${licenceTargetPath}`);
-    fs.copyFileSync(licenceOriginPath, licenceTargetPath);
-  }
-
-  log(`Writing local ESLint config: ${eslintrcTargetPath}`);
-  fs.writeFileSync(eslintrcTargetPath, '{\n  "ignorePatterns": [\n    "*"\n  ]\n}', { flag: 'w' });
-
+  fs.mkdirSync(folderTargetPath, { recursive: true });
   log(`Writing generated schema: ${schemaTargetPath}`);
   fs.writeFileSync(schemaTargetPath, ts, { flag: 'w' });
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/jawj/zapatos"
   },
   "prepublish": "tsc",
-  "main": "dist/generate",
+  "main": "dist/src",
+  "types": "dist/src/index.d.ts",
   "bin": {
     "zapatos": "dist/generate-schema.js"
   },

--- a/src/core.ts
+++ b/src/core.ts
@@ -16,7 +16,7 @@ import type {
   Whereable,
   Table,
   Column,
-} from '../schema';
+} from 'zapatos/schema';
 
 
 // === symbols, types, wrapper classes and shortcuts ===

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -20,7 +20,7 @@ import type {
   Whereable,
   Table,
   Column,
-} from '../schema';
+} from 'zapatos/schema';
 
 import {
   AllType,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,17 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "./dist",
     "target": "es2019",
     "module": "CommonJS",
     "strict": true,
     "declaration": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "paths": {
+      "*": [
+        "typings/*"
+      ]
+    }
   }
 }

--- a/typings/zapatos/schema.ts
+++ b/typings/zapatos/schema.ts
@@ -13,7 +13,7 @@ import type {
   ColumnValues,
   ParentColumn,
   DefaultType,
-} from "./src";
+} from "../../src";
 
 export declare namespace pg_indexes {
   export type Table = "pg_indexes";


### PR DESCRIPTION
Following on from this PR: https://github.com/jawj/zapatos/pull/26

I've tried this branch (heavily inspired by the effort by @eyelidlessness, just updated based on the latest state of master) on my closed source project that uses `ts-jest` and `ts-node-dev` and had no problems with the generated schema being found.

I'd be interested if you are able to reproduce your issue in the open so we can figure out what is going on @jawj. I'm conscious of taking up too much of your time with this but I really feel that it will help adoption of this library if the configuration is less unusual.