### PR TITLE
Added an optional config parameter to skip zapatos ts output generation

### DIFF
--- a/generate/config.ts
+++ b/generate/config.ts
@@ -27,6 +27,7 @@ export interface OptionalConfig {
   progressListener: boolean | ((s: string) => void);
   warningListener: boolean | ((s: string) => void);
   customTypesTransform: 'PgMy_type' | 'my_type' | 'PgMyType' | ((s: string) => string);
+  skipGenerateIfNoTables: boolean;
 }
 
 export type Config = RequiredConfig & Partial<OptionalConfig>;
@@ -39,6 +40,7 @@ const defaultConfig: OptionalConfig = {
   progressListener: false,
   warningListener: true,
   customTypesTransform: 'PgMy_type',
+  skipGenerateIfNoTables: false,
 };
 
 export const moduleRoot = () => {

--- a/generate/tsOutput.ts
+++ b/generate/tsOutput.ts
@@ -93,6 +93,7 @@ export const tsForConfig = async (config: CompleteConfig) => {
     schemaDefs = schemaData.map(r => r.schemaDef).sort(),
     schemaTables = schemaData.map(r => r.tables),
     allTables = ([] as string[]).concat(...schemaTables).sort(),
+    hasTables = allTables.length > 0,
     hasCustomTypes = Object.keys(customTypes).length > 0,
     ts = header() +
       coreImports + '\n' +
@@ -104,5 +105,5 @@ export const tsForConfig = async (config: CompleteConfig) => {
     customTypeSourceFiles = sourceFilesForCustomTypes(customTypes);
 
   await pool.end();
-  return { ts, customTypeSourceFiles };
+  return { ts, customTypeSourceFiles, hasTables };
 };

--- a/generate/write.ts
+++ b/generate/write.ts
@@ -25,7 +25,7 @@ export const generate = async (suppliedConfig: Config) => {
     warn = config.warningListener === true ? console.log :
       config.warningListener || (() => void 0),
 
-    { ts, customTypeSourceFiles } = await tsForConfig(config),
+    { ts, customTypeSourceFiles, hasTables } = await tsForConfig(config),
     folderName = 'zapatos',
     srcName = 'src',
     licenceName = 'LICENCE',
@@ -45,6 +45,13 @@ export const generate = async (suppliedConfig: Config) => {
     eslintrcTargetPath = path.join(folderTargetPath, eslintrcName),
     schemaTargetPath = path.join(folderTargetPath, schemaName),
     customFolderTargetPath = path.join(folderTargetPath, customFolderName);
+	
+  if (config.skipGenerateIfNoTables && !hasTables) {
+    warn(
+      `Generation of zapatos files skipped because 'skipGenerateIfNoTables' is set to 'true' and there are no tables in all configured schemas!`
+    );
+    return;
+  }
 
   if (!fs.existsSync(folderTargetPath)) fs.mkdirSync(folderTargetPath);
 


### PR DESCRIPTION
After enabling ts strict checks the issue #41 has reappeared again (as predicted :) ), so I thought maybe a simpler solution can be made and tried to skip the generation of zapatos output altogether based on an optional config parameter and by checking if there are any tables in all schemas. (It's a lot easier to check on zapatos side then on consumer side)

With this change, previous `any-type` change can potentially be reverted back, but I would not go that far in this PR.

Please have a look if such change is acceptable :)