### PR TITLE
Minor QOL improvements

### DIFF
--- a/src/db/conditions.ts
+++ b/src/db/conditions.ts
@@ -51,11 +51,6 @@ export const notReImatch = <T extends string>(a: T) => sql<SQL, boolean | null, 
 export const isIn = <T>(a: T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} IN (${vals(a)})` : sql`false`;
 export const isNotIn = <T>(a: T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} NOT IN (${vals(a)})` : sql`true`;
 
-export const distanceIsLt = <T extends string>(a: T | SQL, threshold: number) =>
-  sql<SQL, boolean, T>`(${self} <-> ${conditionalParam(a)}) < ${conditionalParam(threshold)}`;
-export const distanceIsGt = <T extends string>(a: T | SQL, threshold: number) =>
-  sql<SQL, boolean, T>`(${self} <-> ${conditionalParam(a)}) > ${conditionalParam(threshold)}`;
-
 export const or = <T>(...conditions: SQLFragment<any, T>[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` OR `, c => c)})`;
 export const and = <T>(...conditions: SQLFragment<any, T>[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` AND `, c => c)})`;
 export const not = <T>(condition: SQLFragment<any, T>) => sql<SQL, boolean | null, T>`(NOT ${condition})`;
@@ -63,7 +58,4 @@ export const not = <T>(condition: SQLFragment<any, T>) => sql<SQL, boolean | nul
 // these are really more operations than conditions, but we sneak them in here for now, for use e.g. in UPDATE queries
 export const add = <T extends number | Date>(a: T) => sql<SQL, number, T>`${self} + ${conditionalParam(a)}`;
 export const subtract = <T extends number | Date>(a: T) => sql<SQL, number, T>`${self} - ${conditionalParam(a)}`;
-
-// helper for defining an ordering in terms of distance
-export const distanceOrder = <T extends string>(a: SQL, b: SQL | T) => sql<SQL, SQL, T>`${a} <-> ${conditionalParam(b)}`;
 

--- a/src/db/conditions.ts
+++ b/src/db/conditions.ts
@@ -51,6 +51,11 @@ export const notReImatch = <T extends string>(a: T) => sql<SQL, boolean | null, 
 export const isIn = <T>(a: T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} IN (${vals(a)})` : sql`false`;
 export const isNotIn = <T>(a: T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} NOT IN (${vals(a)})` : sql`true`;
 
+export const distanceIsLt = <T extends string>(a: T | SQL, threshold: number) =>
+  sql<SQL, boolean, T>`(${self} <-> ${conditionalParam(a)}) < ${conditionalParam(threshold)}`;
+export const distanceIsGt = <T extends string>(a: T | SQL, threshold: number) =>
+  sql<SQL, boolean, T>`(${self} <-> ${conditionalParam(a)}) > ${conditionalParam(threshold)}`;
+
 export const or = <T>(...conditions: SQLFragment<any, T>[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` OR `, c => c)})`;
 export const and = <T>(...conditions: SQLFragment<any, T>[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` AND `, c => c)})`;
 export const not = <T>(condition: SQLFragment<any, T>) => sql<SQL, boolean | null, T>`(NOT ${condition})`;
@@ -58,3 +63,7 @@ export const not = <T>(condition: SQLFragment<any, T>) => sql<SQL, boolean | nul
 // these are really more operations than conditions, but we sneak them in here for now, for use e.g. in UPDATE queries
 export const add = <T extends number | Date>(a: T) => sql<SQL, number, T>`${self} + ${conditionalParam(a)}`;
 export const subtract = <T extends number | Date>(a: T) => sql<SQL, number, T>`${self} - ${conditionalParam(a)}`;
+
+// helper for defining an ordering in terms of distance
+export const distanceOrder = <T extends string>(a: SQL, b: SQL | T) => sql<SQL, SQL, T>`${a} <-> ${conditionalParam(b)}`;
+

--- a/src/db/config.ts
+++ b/src/db/config.ts
@@ -13,7 +13,7 @@ export interface Config {
   castArrayParamsToJson: boolean;   // see https://github.com/brianc/node-postgres/issues/2012
   castObjectParamsToJson: boolean;  // useful if json will be cast onward differently from text
   queryListener?(str: any, txnId?: number): void;
-  resultListener?(str: any, txnId?: number): void;
+  resultListener?(str: any, txnId?: number, timing?: number): void;
   transactionListener?(str: any, txnId?: number): void;
 }
 export type NewConfig = Partial<Config>;

--- a/src/db/core.ts
+++ b/src/db/core.ts
@@ -325,10 +325,10 @@ export class SQLFragment<RunResult = pg.QueryResult['rows'], Constraint = never>
             columnName = columnNames[i],
             columnValue = (<any>expression)[columnName];
 
-          // if the value is undefined, skip the condition. Otherwise you will will end up with
+          // if the value is undefined, throw an error. Otherwise you will will end up with
           // `${value} = undefined` in the SQL which will always be false
           if (typeof columnValue === 'undefined') {
-            continue;
+            throw new Error(`Where condition for ${columnValue} was "undefined"`);
           }
 
           if (i > 0) result.text += ' AND ';


### PR DESCRIPTION
Just a few minor tweaks that have been helpful in my project (it's quite spatial and text search heavy). I'm happy to split it up into multiple PRs if you would prefer but I think its mostly uncontroversial.

- Added some distance operator (`<->`) related conditions (plus an ordering one that doesn't quite fit as a "condition" but maybe its okay to sneak it in alongside the `or` and `and` ones).
- Added a performance monitoring parameter to the `resultListener` callback. This has been particularly helpful debugging query performance and will likely be useful for general logging down the track
- I hit an issue where I was constructing a where clause like this:

```
const res = await db.select('cats', { breed: params?.breed }).run(pgPool);
```

but this didn't work properly as the `undefined` string ended up in the generated SQL. I added in a check to just ignore the condition if its undefined.