### PR TITLE
Add support for schema generation for materialized views

### DIFF
--- a/src/generate/tables.ts
+++ b/src/generate/tables.ts
@@ -10,27 +10,48 @@ import type { EnumData } from './enums';
 import type { CustomTypes } from './tsOutput';
 import { CompleteConfig } from './config';
 
-export const tablesInSchema = async (schemaName: string, pool: pg.Pool): Promise<string[]> => {
+export interface TableMeta {
+  tableName: string;
+  tableType: string;
+}
+
+export const tablesInSchema = async (schemaName: string, pool: pg.Pool): Promise<TableMeta[]> => {
   const { rows } = await pool.query({
     text: `
-      SELECT "table_name" FROM "information_schema"."columns"
+      SELECT "table_name", 'table'::TEXT AS table_type
+      FROM "information_schema"."columns"
       WHERE "table_schema" = $1 
       GROUP BY "table_name" ORDER BY lower("table_name")`,
     values: [schemaName]
   });
 
-  return rows.map(r => r.table_name);
+  const { rows: rowsV } = await pool.query({
+    text: `
+      SELECT
+          pg_class.relname AS table_name
+        , 'materialized view'::TEXT AS table_type
+
+      FROM pg_catalog.pg_class
+
+      INNER JOIN pg_catalog.pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+
+      WHERE pg_class.relkind = 'm'
+        AND pg_namespace.nspname = $1
+    `,
+    values: [schemaName]
+  });
+
+  return rows.concat(rowsV).map(r => ({
+    tableName: r.table_name,
+    tableType: r.table_type,
+  }));
 };
 
-export const definitionForTableInSchema = async (
-  tableName: string,
+const columnsForTable = async(
+  table: TableMeta,
   schemaName: string,
-  enums: EnumData,
-  customTypes: CustomTypes,  // an 'out' parameter
-  config: CompleteConfig,
   pool: pg.Pool,
 ) => {
-
   const
     { rows } = await pool.query({
       text: `
@@ -43,13 +64,74 @@ export const definitionForTableInSchema = async (
         , "domain_name" AS "domainName"
         FROM "information_schema"."columns"
         WHERE "table_name" = $1 AND "table_schema" = $2`,
-      values: [tableName, schemaName]
-    }),
+      values: [table.tableName, schemaName]
+    });
 
+  return rows;
+};
+
+const columnsForMaterializedView = async(
+  table: TableMeta,
+  schemaName: string,
+  pool: pg.Pool,
+) => {
+  const
+    { rows } = await pool.query({
+      text: `
+        SELECT
+          a.attname AS "column"
+        , a.attnotnull = 'f' AS "isNullable"
+        , 't' AS "isGenerated" -- You can't write to materalized views
+        , 'f' AS "hasDefault"
+        , pg_catalog.format_type(a.atttypid, a.atttypmod) AS "udtName"
+        , '?' AS "domainName"
+
+      FROM pg_catalog.pg_class
+
+      INNER JOIN pg_catalog.pg_attribute a ON pg_class.oid = a.attrelid
+      INNER JOIN pg_catalog.pg_namespace n ON pg_class.relnamespace = n.oid
+
+      WHERE pg_class.relkind = 'm'
+        AND a.attnum >= 1
+        AND pg_class.relname = $1
+        AND n.nspname = $2
+      `,
+      values: [table.tableName, schemaName]
+    });
+
+  return rows;
+};
+
+export const definitionForTableInSchema = async (
+  table: TableMeta,
+  schemaName: string,
+  enums: EnumData,
+  customTypes: CustomTypes,  // an 'out' parameter
+  config: CompleteConfig,
+  pool: pg.Pool,
+) => {
+  let rows;
+  if (table.tableType === 'materialized view') {
+    rows = await columnsForMaterializedView(
+      table,
+      schemaName,
+      pool
+    );
+  } else {
+    rows = await columnsForTable(
+      table,
+      schemaName,
+      pool
+    );
+  }
+
+  const
     selectables: string[] = [],
     whereables: string[] = [],
     insertables: string[] = [],
     updatables: string[] = [];
+
+  const tableName = table.tableName;
 
   rows.forEach(row => {
     const { column, isGenerated, isNullable, hasDefault, udtName, domainName } = row;


### PR DESCRIPTION
Hey Jawj,

We have materialized views in our schema so we decided it was worthwhile to add support to zapatos for generating a schema for them.

The implementation doesn't do anything too crazy, it just runs a different introspection query to get the same info as for regular tables (column name, data type, isNullable) and hardcodes `isGenerated` to true as you can't write to materialized views. 

It also passes around a `tableType` arg with the table name that can be "table" or "materialized view". I suspect it will be easy to add regular views as well but we are not using them currently so I decided to keep that out of scope for now.

Are you happy with this approach?