### PR TITLE
Add basic Github Actions CI

### DIFF
--- a/.github/workflows/zapatos.yaml
+++ b/.github/workflows/zapatos.yaml
@@ -1,0 +1,33 @@
+name: zapatos
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    container:
+      image: node:14.17.0-buster-slim
+    timeout-minutes: 3
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: npm
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Adding Github Actions to get started on https://github.com/jawj/zapatos/issues/16. Not sure how much time I will have to dedicate to actual tests, but with this change we'll at least ensure that the code passes ESLint and builds correctly on every push and PR.

Edit: it seems that this won't run on the original repo until it's merged. I think you can merge it into a non-master branch to try it out or you can take a look at https://github.com/jgonera/zapatos/actions. "Test CI" is a commit I removed that added a wrong type and broke an ESLint rule.