### PR TITLE
Fix transactions returning bad connections to the pool

### DIFF
--- a/src/db/transaction.ts
+++ b/src/db/transaction.ts
@@ -91,6 +91,7 @@ export async function transaction<T, M extends IsolationLevel>(
 
   if (txnSeq >= Number.MAX_SAFE_INTEGER - 1) txnSeq = 0;  // wrap around
 
+  let released = false;
   const
     txnId = txnSeq++,
     clientIsOurs = typeofQueryable(txnClientOrQueryable) === 'pool',
@@ -140,9 +141,12 @@ export async function transaction<T, M extends IsolationLevel>(
       }
     }
 
+  } catch (err) {
+    if (clientIsOurs && !released) txnClient.release(err);
+    throw err;
   } finally {
     delete txnClient._zapatos;
-    if (clientIsOurs) txnClient.release();
+    if (clientIsOurs && !released) txnClient.release();
   }
 }
 


### PR DESCRIPTION
Currently, errors in transactions do not get propagated to the pool. This means failed connections will get returned to the pool, effectively poisoning the well. This change simply passes exceptions back to the pool when they occur, allowing the connection to be dropped.