### PR TITLE
Add value in lateral and sub-query support

### DIFF
--- a/db.mjs
+++ b/db.mjs
@@ -26,6 +26,7 @@ export const isDatabaseError = mod.isDatabaseError;
 export const mapWithSeparator = mod.mapWithSeparator;
 export const max = mod.max;
 export const min = mod.min;
+export const nested = mod.nested;
 export const param = mod.param;
 export const parent = mod.parent;
 export const raw = mod.raw;

--- a/src/db/conditions.ts
+++ b/src/db/conditions.ts
@@ -13,12 +13,17 @@ import {
   SQL,
   self,
   vals,
-} from './core';
+} from "./core";
 
-import { mapWithSeparator } from './utils';
-import type { Whereable } from 'zapatos/schema';
+import { mapWithSeparator } from "./utils";
+import type { Whereable } from "zapatos/schema";
 
-const conditionalParam = (a: any) => a instanceof SQLFragment || a instanceof ParentColumn || a instanceof Parameter ? a : param(a);
+const conditionalParam = (a: any) =>
+  a instanceof SQLFragment ||
+  a instanceof ParentColumn ||
+  a instanceof Parameter
+    ? a
+    : param(a);
 
 export const isNull = sql<SQL, boolean>`${self} IS NULL`;
 export const isNotNull = sql<SQL, boolean>`${self} IS NOT NULL`;
@@ -29,47 +34,116 @@ export const isNotFalse = sql<SQL, boolean>`${self} IS NOT FALSE`;
 export const isUnknown = sql<SQL, boolean>`${self} IS UNKNOWN`;
 export const isNotUnknown = sql<SQL, boolean>`${self} IS NOT UNKNOWN`;
 
-export const isDistinctFrom = <T>(a: T) => sql<SQL, boolean, T>`${self} IS DISTINCT FROM ${conditionalParam(a)}`;
-export const isNotDistinctFrom = <T>(a: T) => sql<SQL, boolean, T>`${self} IS NOT DISTINCT FROM ${conditionalParam(a)}`;
+export const isDistinctFrom = <T>(a: T) =>
+  sql<SQL, boolean, T>`${self} IS DISTINCT FROM ${conditionalParam(a)}`;
+export const isNotDistinctFrom = <T>(a: T) =>
+  sql<SQL, boolean, T>`${self} IS NOT DISTINCT FROM ${conditionalParam(a)}`;
 
-export const eq = <T>(a: T) => sql<SQL, boolean | null, T>`${self} = ${conditionalParam(a)}`;
-export const ne = <T>(a: T) => sql<SQL, boolean | null, T>`${self} <> ${conditionalParam(a)}`;
-export const gt = <T>(a: T) => sql<SQL, boolean | null, T>`${self} > ${conditionalParam(a)}`;
-export const gte = <T>(a: T) => sql<SQL, boolean | null, T>`${self} >= ${conditionalParam(a)}`;
-export const lt = <T>(a: T) => sql<SQL, boolean | null, T>`${self} < ${conditionalParam(a)}`;
-export const lte = <T>(a: T) => sql<SQL, boolean | null, T>`${self} <= ${conditionalParam(a)}`;
+export const eq = <T>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} = ${conditionalParam(a)}`;
+export const ne = <T>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} <> ${conditionalParam(a)}`;
+export const gt = <T>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} > ${conditionalParam(a)}`;
+export const gte = <T>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} >= ${conditionalParam(a)}`;
+export const lt = <T>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} < ${conditionalParam(a)}`;
+export const lte = <T>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} <= ${conditionalParam(a)}`;
 
-export const between = <T>(a: T, b: T) => sql<SQL, boolean | null, T> `${self} BETWEEN (${conditionalParam(a)}) AND (${conditionalParam(b)})`;
-export const betweenSymmetric = <T>(a: T, b: T) => sql<SQL, boolean | null, T> `${self} BETWEEN SYMMETRIC (${conditionalParam(a)}) AND (${conditionalParam(b)})`;
-export const notBetween = <T>(a: T, b: T) => sql<SQL, boolean | null, T> `${self} NOT BETWEEN (${conditionalParam(a)}) AND (${conditionalParam(b)})`;
-export const notBetweenSymmetric = <T>(a: T, b: T) => sql<SQL, boolean | null, T> `${self} NOT BETWEEN SYMMETRIC (${conditionalParam(a)}) AND (${conditionalParam(b)})`;
+export const between = <T>(a: T, b: T) =>
+  sql<SQL, boolean | null, T>`${self} BETWEEN (${conditionalParam(
+    a
+  )}) AND (${conditionalParam(b)})`;
+export const betweenSymmetric = <T>(a: T, b: T) =>
+  sql<SQL, boolean | null, T>`${self} BETWEEN SYMMETRIC (${conditionalParam(
+    a
+  )}) AND (${conditionalParam(b)})`;
+export const notBetween = <T>(a: T, b: T) =>
+  sql<SQL, boolean | null, T>`${self} NOT BETWEEN (${conditionalParam(
+    a
+  )}) AND (${conditionalParam(b)})`;
+export const notBetweenSymmetric = <T>(a: T, b: T) =>
+  sql<SQL, boolean | null, T>`${self} NOT BETWEEN SYMMETRIC (${conditionalParam(
+    a
+  )}) AND (${conditionalParam(b)})`;
 
-export const like = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} LIKE ${conditionalParam(a)}`;
-export const notLike = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} NOT LIKE ${conditionalParam(a)}`;
-export const ilike = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} ILIKE ${conditionalParam(a)}`;
-export const notIlike = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} NOT ILIKE ${conditionalParam(a)}`;
-export const similarTo = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} SIMILAR TO ${conditionalParam(a)}`;
-export const notSimilarTo = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} NOT SIMILAR TO ${conditionalParam(a)}`;
-export const reMatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} ~ ${conditionalParam(a)}`;
-export const reImatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} ~* ${conditionalParam(a)}`;
-export const notReMatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} !~ ${conditionalParam(a)}`;
-export const notReImatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} !~* ${conditionalParam(a)}`;
+export const like = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} LIKE ${conditionalParam(a)}`;
+export const notLike = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} NOT LIKE ${conditionalParam(a)}`;
+export const ilike = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} ILIKE ${conditionalParam(a)}`;
+export const notIlike = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} NOT ILIKE ${conditionalParam(a)}`;
+export const similarTo = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} SIMILAR TO ${conditionalParam(a)}`;
+export const notSimilarTo = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} NOT SIMILAR TO ${conditionalParam(a)}`;
+export const reMatch = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} ~ ${conditionalParam(a)}`;
+export const reImatch = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} ~* ${conditionalParam(a)}`;
+export const notReMatch = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} !~ ${conditionalParam(a)}`;
+export const notReImatch = <T extends string>(a: T) =>
+  sql<SQL, boolean | null, T>`${self} !~* ${conditionalParam(a)}`;
 
-export const isIn = <T>(a: readonly T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} IN (${vals(a)})` : sql`false`;
-export const isNotIn = <T>(a: readonly T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} NOT IN (${vals(a)})` : sql`true`;
-
-export const or = <T>(...conditions: SQLFragment<any, T>[] | Whereable[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` OR `, c => c)})`;
-export const and = <T>(...conditions: SQLFragment<any, T>[] | Whereable[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` AND `, c => c)})`;
-export const not = <T>(condition: SQLFragment<any, T> | Whereable) => sql<SQL, boolean | null, T>`(NOT ${condition})`;
+export const isIn = <T>(a: readonly T[]) =>
+  "run" in a
+    ? sql`${self} IN ${a}`
+    : a.length > 0
+    ? sql<SQL, boolean | null, T>`${self} IN (${vals(a)})`
+    : sql`false`;
+export const isNotIn = <T>(a: readonly T[]) =>
+  "run" in a
+    ? sql`${self} NOT IN ${a}`
+    : a.length > 0
+    ? sql<SQL, boolean | null, T>`${self} NOT IN (${vals(a)})`
+    : sql`true`;
+export const or = <T>(...conditions: SQLFragment<any, T>[] | Whereable[]) =>
+  sql<SQL, boolean | null, T>`(${mapWithSeparator(
+    conditions,
+    sql` OR `,
+    (c) => c
+  )})`;
+export const and = <T>(...conditions: SQLFragment<any, T>[] | Whereable[]) =>
+  sql<SQL, boolean | null, T>`(${mapWithSeparator(
+    conditions,
+    sql` AND `,
+    (c) => c
+  )})`;
+export const not = <T>(condition: SQLFragment<any, T> | Whereable) =>
+  sql<SQL, boolean | null, T>`(NOT ${condition})`;
 
 // things that aren't genuinely conditions
-type PluralisingIntervalUnit = 'microsecond' | 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' | 'decade';
-type IntervalUnit = PluralisingIntervalUnit | `${PluralisingIntervalUnit}s` | 'century' | 'centuries' | 'millennium' | 'millennia';
-export const fromNow = (n: number, unit: IntervalUnit = 'millisecond') => sql`now() + ${param(String(n) + ' ' + unit)}`;
+type PluralisingIntervalUnit =
+  | "microsecond"
+  | "millisecond"
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year"
+  | "decade";
+type IntervalUnit =
+  | PluralisingIntervalUnit
+  | `${PluralisingIntervalUnit}s`
+  | "century"
+  | "centuries"
+  | "millennium"
+  | "millennia";
+export const fromNow = (n: number, unit: IntervalUnit = "millisecond") =>
+  sql`now() + ${param(String(n) + " " + unit)}`;
 export const after = gt;
 export const before = lt;
 export const now = sql`now()`;
 
 // these are really more operations than conditions, but we sneak them in here for now, for use e.g. in UPDATE queries
-export const add = <T extends number | Date>(a: T) => sql<SQL, number, T>`${self} + ${conditionalParam(a)}`;
-export const subtract = <T extends number | Date>(a: T) => sql<SQL, number, T>`${self} - ${conditionalParam(a)}`;
+export const add = <T extends number | Date>(a: T) =>
+  sql<SQL, number, T>`${self} + ${conditionalParam(a)}`;
+export const subtract = <T extends number | Date>(a: T) =>
+  sql<SQL, number, T>`${self} - ${conditionalParam(a)}`;

--- a/src/db/shortcuts.ts
+++ b/src/db/shortcuts.ts
@@ -17,7 +17,7 @@ import type {
   Whereable,
   Table,
   Column,
-} from 'zapatos/schema';
+} from "zapatos/schema";
 
 import {
   AllType,
@@ -30,25 +30,40 @@ import {
   raw,
   param,
   Default,
-} from './core';
+} from "./core";
 
 import {
   completeKeysWithDefaultValue,
   mapWithSeparator,
   NoInfer,
-} from './utils';
+} from "./utils";
 
+export type JSONOnlyColsForTable<
+  T extends Table,
+  C extends any[] /* `ColumnForTable<T>[]` gives errors here for reasons I haven't got to the bottom of */
+> = Pick<JSONSelectableForTable<T>, C[number]>;
 
-export type JSONOnlyColsForTable<T extends Table, C extends any[] /* `ColumnForTable<T>[]` gives errors here for reasons I haven't got to the bottom of */> =
-  Pick<JSONSelectableForTable<T>, C[number]>;
+export interface SQLFragmentMap {
+  [k: string]: SQLFragment<any>;
+}
+export interface SQLFragmentOrColumnMap<T extends Table> {
+  [k: string]: SQLFragment<any> | ColumnForTable<T>;
+}
+export type RunResultForSQLFragment<T extends SQLFragment<any, any>> =
+  T extends SQLFragment<infer RunResult, any> ? RunResult : never;
 
-export interface SQLFragmentMap { [k: string]: SQLFragment<any> }
-export interface SQLFragmentOrColumnMap<T extends Table> { [k: string]: SQLFragment<any> | ColumnForTable<T> }
-export type RunResultForSQLFragment<T extends SQLFragment<any, any>> = T extends SQLFragment<infer RunResult, any> ? RunResult : never;
-
-export type LateralResult<L extends SQLFragmentMap> = { [K in keyof L]: RunResultForSQLFragment<L[K]> };
-export type ExtrasResult<T extends Table, E extends SQLFragmentOrColumnMap<T>> = { [K in keyof E]:
-  E[K] extends SQLFragment<any> ? RunResultForSQLFragment<E[K]> : E[K] extends keyof JSONSelectableForTable<T> ? JSONSelectableForTable<T>[E[K]] : never;
+export type LateralResult<L extends SQLFragmentMap> = {
+  [K in keyof L]: RunResultForSQLFragment<L[K]>;
+};
+export type ExtrasResult<
+  T extends Table,
+  E extends SQLFragmentOrColumnMap<T>
+> = {
+  [K in keyof E]: E[K] extends SQLFragment<any>
+    ? RunResultForSQLFragment<E[K]>
+    : E[K] extends keyof JSONSelectableForTable<T>
+    ? JSONSelectableForTable<T>[E[K]]
+    : never;
 };
 
 type ExtrasOption<T extends Table> = SQLFragmentOrColumnMap<T> | undefined;
@@ -58,35 +73,59 @@ type LimitedLateralOption = SQLFragmentMap | undefined;
 type FullLateralOption = LimitedLateralOption | SQLFragment<any>;
 type LateralOption<
   C extends ColumnsOption<Table>,
-  E extends ExtrasOption<Table>,
-> =
-  undefined extends C ? undefined extends E ? FullLateralOption : LimitedLateralOption : LimitedLateralOption;
+  E extends ExtrasOption<Table>
+> = undefined extends C
+  ? undefined extends E
+    ? FullLateralOption
+    : LimitedLateralOption
+  : LimitedLateralOption;
 
-export interface ReturningOptionsForTable<T extends Table, C extends ColumnsOption<T>, E extends ExtrasOption<T>> {
+export interface ReturningOptionsForTable<
+  T extends Table,
+  C extends ColumnsOption<T>,
+  E extends ExtrasOption<T>
+> {
   returning?: C;
   extras?: E;
-};
+}
 
-type ReturningTypeForTable<T extends Table, C extends ColumnsOption<T>, E extends ExtrasOption<T>> =
-  (undefined extends C ? JSONSelectableForTable<T> :
-    C extends ColumnForTable<T>[] ? JSONOnlyColsForTable<T, C> :
-    never) &
-  (undefined extends E ? {} :
-    E extends SQLFragmentOrColumnMap<T> ? ExtrasResult<T, E> :
-    never);
+type ReturningTypeForTable<
+  T extends Table,
+  C extends ColumnsOption<T>,
+  E extends ExtrasOption<T>
+> = (undefined extends C
+  ? JSONSelectableForTable<T>
+  : C extends ColumnForTable<T>[]
+  ? JSONOnlyColsForTable<T, C>
+  : never) &
+  (undefined extends E
+    ? {}
+    : E extends SQLFragmentOrColumnMap<T>
+    ? ExtrasResult<T, E>
+    : never);
 
-
-function SQLForColumnsOfTable(columns: readonly Column[] | undefined, table: Table) {
-  return columns === undefined ? sql`to_jsonb(${table}.*)` :
-    sql`jsonb_build_object(${mapWithSeparator(columns, sql`, `, c => sql`${param(c)}::text, ${c}`)})`;
+function SQLForColumnsOfTable(
+  columns: readonly Column[] | undefined,
+  table: Table
+) {
+  return columns === undefined
+    ? sql`to_jsonb(${table}.*)`
+    : sql`jsonb_build_object(${mapWithSeparator(
+        columns,
+        sql`, `,
+        (c) => sql`${param(c)}::text, ${c}`
+      )})`;
 }
 
 function SQLForExtras<T extends Table>(extras: ExtrasOption<T>) {
-  return extras === undefined ? [] :
-    sql` || jsonb_build_object(${mapWithSeparator(
-      Object.keys(extras), sql`, `, k => sql`${param(k)}::text, ${extras[k]}`)})`;
+  return extras === undefined
+    ? []
+    : sql` || jsonb_build_object(${mapWithSeparator(
+        Object.keys(extras),
+        sql`, `,
+        (k) => sql`${param(k)}::text, ${extras[k]}`
+      )})`;
 }
-
 
 /* === insert === */
 
@@ -112,35 +151,43 @@ interface InsertSignatures {
 export const insert: InsertSignatures = function (
   table: Table,
   values: Insertable | Insertable[],
-  options?: ReturningOptionsForTable<Table, ColumnsOption<Table>, ExtrasOption<Table>>
+  options?: ReturningOptionsForTable<
+    Table,
+    ColumnsOption<Table>,
+    ExtrasOption<Table>
+  >
 ): SQLFragment<any> {
-
   let query;
   if (Array.isArray(values) && values.length === 0) {
     query = sql`INSERT INTO ${table} SELECT null WHERE false`;
     query.noop = true;
     query.noopResult = [];
-
   } else {
-    const
-      completedValues = Array.isArray(values) ? completeKeysWithDefaultValue(values, Default) : values,
-      colsSQL = cols(Array.isArray(completedValues) ? completedValues[0] : completedValues),
-      valuesSQL = Array.isArray(completedValues) ?
-        mapWithSeparator(completedValues as Insertable[], sql`, `, v => sql`(${vals(v)})`) :
-        sql`(${vals(completedValues)})`,
+    const completedValues = Array.isArray(values)
+        ? completeKeysWithDefaultValue(values, Default)
+        : values,
+      colsSQL = cols(
+        Array.isArray(completedValues) ? completedValues[0] : completedValues
+      ),
+      valuesSQL = Array.isArray(completedValues)
+        ? mapWithSeparator(
+            completedValues as Insertable[],
+            sql`, `,
+            (v) => sql`(${vals(v)})`
+          )
+        : sql`(${vals(completedValues)})`,
       returningSQL = SQLForColumnsOfTable(options?.returning, table),
       extrasSQL = SQLForExtras(options?.extras);
 
     query = sql`INSERT INTO ${table} (${colsSQL}) VALUES ${valuesSQL} RETURNING ${returningSQL}${extrasSQL} AS result`;
   }
 
-  query.runResultTransform = Array.isArray(values) ?
-    (qr) => qr.rows.map(r => r.result) :
-    (qr) => qr.rows[0].result;
+  query.runResultTransform = Array.isArray(values)
+    ? (qr) => qr.rows.map((r) => r.result)
+    : (qr) => qr.rows[0].result;
 
   return query;
 };
-
 
 /* === upsert === */
 
@@ -148,25 +195,33 @@ export const insert: InsertSignatures = function (
  * Wraps a unique index of the target table for use as the arbiter constraint
  * of an `upsert` shortcut query.
  */
-export class Constraint<T extends Table> { constructor(public value: UniqueIndexForTable<T>) { } }
+export class Constraint<T extends Table> {
+  constructor(public value: UniqueIndexForTable<T>) {}
+}
 /**
  * Returns a `Constraint` instance, wrapping a unique index of the target table
  * for use as the arbiter constraint of an `upsert` shortcut query.
  */
-export function constraint<T extends Table>(x: UniqueIndexForTable<T>) { return new Constraint<T>(x); }
+export function constraint<T extends Table>(x: UniqueIndexForTable<T>) {
+  return new Constraint<T>(x);
+}
 
-export interface UpsertAction { $action: 'INSERT' | 'UPDATE' }
+export interface UpsertAction {
+  $action: "INSERT" | "UPDATE";
+}
 
-type UpsertReportAction = 'suppress';
+type UpsertReportAction = "suppress";
 type UpsertReturnableForTable<
   T extends Table,
   C extends ColumnsOption<T>,
   E extends ExtrasOption<T>,
   RA extends UpsertReportAction | undefined
-> =
-  ReturningTypeForTable<T, C, E> & (undefined extends RA ? UpsertAction : {});
+> = ReturningTypeForTable<T, C, E> & (undefined extends RA ? UpsertAction : {});
 
-type UpsertConflictTargetForTable<T extends Table> = Constraint<T> | ColumnForTable<T> | ColumnForTable<T>[];
+type UpsertConflictTargetForTable<T extends Table> =
+  | Constraint<T>
+  | ColumnForTable<T>
+  | ColumnForTable<T>[];
 type UpdateColumns<T extends Table> = ColumnForTable<T> | ColumnForTable<T>[];
 
 interface UpsertOptions<
@@ -174,7 +229,7 @@ interface UpsertOptions<
   C extends ColumnsOption<T>,
   E extends ExtrasOption<T>,
   UC extends UpdateColumns<T> | undefined,
-  RA extends UpsertReportAction | undefined,
+  RA extends UpsertReportAction | undefined
 > extends ReturningOptionsForTable<T, C, E> {
   updateValues?: UpdatableForTable<T>;
   updateColumns?: UC;
@@ -183,7 +238,8 @@ interface UpsertOptions<
 }
 
 interface UpsertSignatures {
-  <T extends Table,
+  <
+    T extends Table,
     C extends ColumnsOption<T>,
     E extends ExtrasOption<T>,
     UC extends UpdateColumns<T> | undefined,
@@ -193,9 +249,13 @@ interface UpsertSignatures {
     values: InsertableForTable<T>,
     conflictTarget: UpsertConflictTargetForTable<T>,
     options?: UpsertOptions<T, C, E, UC, RA>
-  ): SQLFragment<UpsertReturnableForTable<T, C, E, RA> | (UC extends never[] ? undefined : never)>;
+  ): SQLFragment<
+    | UpsertReturnableForTable<T, C, E, RA>
+    | (UC extends never[] ? undefined : never)
+  >;
 
-  <T extends Table,
+  <
+    T extends Table,
     C extends ColumnsOption<T>,
     E extends ExtrasOption<T>,
     UC extends UpdateColumns<T> | undefined,
@@ -213,9 +273,9 @@ export const doNothing = [];
 /**
  * Generate an 'upsert' (`INSERT ... ON CONFLICT ...`) query `SQLFragment`.
  * @param table The table to update or insert into
- * @param values An `Insertable` of values (or an array thereof) to be inserted 
+ * @param values An `Insertable` of values (or an array thereof) to be inserted
  * or updated
- * @param conflictTarget A `UNIQUE`-indexed column (or array thereof) or a 
+ * @param conflictTarget A `UNIQUE`-indexed column (or array thereof) or a
  * `UNIQUE` index (wrapped in `db.constraint(...)`) that determines whether we
  * get an `UPDATE` (when there's a matching existing value) or an `INSERT`
  * (when there isn't)
@@ -226,58 +286,84 @@ export const upsert: UpsertSignatures = function (
   table: Table,
   values: Insertable | Insertable[],
   conflictTarget: Column | Column[] | Constraint<Table>,
-  options?: UpsertOptions<Table, ColumnsOption<Table>, ExtrasOption<Table>, UpdateColumns<Table>, UpsertReportAction>
+  options?: UpsertOptions<
+    Table,
+    ColumnsOption<Table>,
+    ExtrasOption<Table>,
+    UpdateColumns<Table>,
+    UpsertReportAction
+  >
 ): SQLFragment<any> {
-
-  if (Array.isArray(values) && values.length === 0) return insert(table, values);  // punt a no-op to plain insert
-  if (typeof conflictTarget === 'string') conflictTarget = [conflictTarget];  // now either Column[] or Constraint
+  if (Array.isArray(values) && values.length === 0) {
+    return insert(table, values);
+  } // punt a no-op to plain insert
+  if (typeof conflictTarget === "string") conflictTarget = [conflictTarget]; // now either Column[] or Constraint
 
   let noNullUpdateColumns = options?.noNullUpdateColumns ?? [];
-  if (!Array.isArray(noNullUpdateColumns)) noNullUpdateColumns = [noNullUpdateColumns];
+  if (!Array.isArray(noNullUpdateColumns)) {
+    noNullUpdateColumns = [noNullUpdateColumns];
+  }
 
   let specifiedUpdateColumns = options?.updateColumns;
-  if (specifiedUpdateColumns && !Array.isArray(specifiedUpdateColumns)) specifiedUpdateColumns = [specifiedUpdateColumns];
+  if (specifiedUpdateColumns && !Array.isArray(specifiedUpdateColumns)) {
+    specifiedUpdateColumns = [specifiedUpdateColumns];
+  }
 
-  const
-    completedValues = Array.isArray(values) ? completeKeysWithDefaultValue(values, Default) : [values],
+  const completedValues = Array.isArray(values)
+      ? completeKeysWithDefaultValue(values, Default)
+      : [values],
     firstRow = completedValues[0],
     insertColsSQL = cols(firstRow),
-    insertValuesSQL = mapWithSeparator(completedValues, sql`, `, v => sql`(${vals(v)})`),
+    insertValuesSQL = mapWithSeparator(
+      completedValues,
+      sql`, `,
+      (v) => sql`(${vals(v)})`
+    ),
     colNames = Object.keys(firstRow) as Column[],
     updateValues = options?.updateValues ?? {},
-    updateColumns = [...new Set(  // deduplicate the keys here
-      [...specifiedUpdateColumns as string[] ?? colNames, ...Object.keys(updateValues)]
-    )],
-    conflictTargetSQL = Array.isArray(conflictTarget) ?
-      sql`(${mapWithSeparator(conflictTarget, sql`, `, c => c)})` :
-      sql<string>`ON CONSTRAINT ${conflictTarget.value}`,
-    updateColsSQL = mapWithSeparator(updateColumns, sql`, `, c => c),
-    updateValuesSQL = mapWithSeparator(updateColumns, sql`, `, c =>
-      updateValues[c] !== undefined ? updateValues[c] :
-        noNullUpdateColumns.includes(c) ? sql`CASE WHEN EXCLUDED.${c} IS NULL THEN ${table}.${c} ELSE EXCLUDED.${c} END` :
-          sql`EXCLUDED.${c}`),
+    updateColumns = [
+      ...new Set([
+        // deduplicate the keys here
+        ...((specifiedUpdateColumns as string[]) ?? colNames),
+        ...Object.keys(updateValues),
+      ]),
+    ],
+    conflictTargetSQL = Array.isArray(conflictTarget)
+      ? sql`(${mapWithSeparator(conflictTarget, sql`, `, (c) => c)})`
+      : sql<string>`ON CONSTRAINT ${conflictTarget.value}`,
+    updateColsSQL = mapWithSeparator(updateColumns, sql`, `, (c) => c),
+    updateValuesSQL = mapWithSeparator(updateColumns, sql`, `, (c) =>
+      updateValues[c] !== undefined
+        ? updateValues[c]
+        : noNullUpdateColumns.includes(c)
+        ? sql`CASE WHEN EXCLUDED.${c} IS NULL THEN ${table}.${c} ELSE EXCLUDED.${c} END`
+        : sql`EXCLUDED.${c}`
+    ),
     returningSQL = SQLForColumnsOfTable(options?.returning, table),
     extrasSQL = SQLForExtras(options?.extras),
-    suppressReport = options?.reportAction === 'suppress';
+    suppressReport = options?.reportAction === "suppress";
 
   // the added-on $action = 'INSERT' | 'UPDATE' key takes after SQL Server's approach to MERGE
   // (and on the use of xmax for this purpose, see: https://stackoverflow.com/questions/39058213/postgresql-upsert-differentiate-inserted-and-updated-rows-using-system-columns-x)
 
-  const
-    insertPart = sql`INSERT INTO ${table} (${insertColsSQL}) VALUES ${insertValuesSQL}`,
+  const insertPart = sql`INSERT INTO ${table} (${insertColsSQL}) VALUES ${insertValuesSQL}`,
     conflictPart = sql`ON CONFLICT ${conflictTargetSQL} DO`,
-    conflictActionPart = updateColsSQL.length > 0 ? sql`UPDATE SET (${updateColsSQL}) = ROW(${updateValuesSQL})` : sql`NOTHING`,
+    conflictActionPart =
+      updateColsSQL.length > 0
+        ? sql`UPDATE SET (${updateColsSQL}) = ROW(${updateValuesSQL})`
+        : sql`NOTHING`,
     reportPart = sql` || jsonb_build_object('$action', CASE xmax WHEN 0 THEN 'INSERT' ELSE 'UPDATE' END)`,
-    returningPart = sql`RETURNING ${returningSQL}${extrasSQL}${suppressReport ? [] : reportPart} AS result`,
+    returningPart = sql`RETURNING ${returningSQL}${extrasSQL}${
+      suppressReport ? [] : reportPart
+    } AS result`,
     query = sql`${insertPart} ${conflictPart} ${conflictActionPart} ${returningPart}`;
 
-  query.runResultTransform = Array.isArray(values) ?
-    (qr) => qr.rows.map(r => r.result) :
-    (qr) => qr.rows[0]?.result;
+  query.runResultTransform = Array.isArray(values)
+    ? (qr) => qr.rows.map((r) => r.result)
+    : (qr) => qr.rows[0]?.result;
 
   return query;
 };
-
 
 /* === update === */
 
@@ -300,21 +386,24 @@ export const update: UpdateSignatures = function (
   table: Table,
   values: Updatable,
   where: Whereable | SQLFragment<any>,
-  options?: ReturningOptionsForTable<Table, ColumnsOption<Table>, ExtrasOption<Table>>
+  options?: ReturningOptionsForTable<
+    Table,
+    ColumnsOption<Table>,
+    ExtrasOption<Table>
+  >
 ): SQLFragment {
-
   // note: the ROW() constructor below is required in Postgres 10+ if we're updating a single column
   // more info: https://www.postgresql-archive.org/Possible-regression-in-UPDATE-SET-lt-column-list-gt-lt-row-expression-gt-with-just-one-single-column0-td5989074.html
 
-  const
-    returningSQL = SQLForColumnsOfTable(options?.returning, table),
+  const returningSQL = SQLForColumnsOfTable(options?.returning, table),
     extrasSQL = SQLForExtras(options?.extras),
-    query = sql`UPDATE ${table} SET (${cols(values)}) = ROW(${vals(values)}) WHERE ${where} RETURNING ${returningSQL}${extrasSQL} AS result`;
+    query = sql`UPDATE ${table} SET (${cols(values)}) = ROW(${vals(
+      values
+    )}) WHERE ${where} RETURNING ${returningSQL}${extrasSQL} AS result`;
 
-  query.runResultTransform = (qr) => qr.rows.map(r => r.result);
+  query.runResultTransform = (qr) => qr.rows.map((r) => r.result);
   return query;
 };
-
 
 /* === delete === */
 
@@ -334,65 +423,74 @@ export interface DeleteSignatures {
 export const deletes: DeleteSignatures = function (
   table: Table,
   where: Whereable | SQLFragment<any>,
-  options?: ReturningOptionsForTable<Table, ColumnsOption<Table>, ExtrasOption<Table>>
+  options?: ReturningOptionsForTable<
+    Table,
+    ColumnsOption<Table>,
+    ExtrasOption<Table>
+  >
 ): SQLFragment {
-
-  const
-    returningSQL = SQLForColumnsOfTable(options?.returning, table),
+  const returningSQL = SQLForColumnsOfTable(options?.returning, table),
     extrasSQL = SQLForExtras(options?.extras),
     query = sql`DELETE FROM ${table} WHERE ${where} RETURNING ${returningSQL}${extrasSQL} AS result`;
 
-  query.runResultTransform = (qr) => qr.rows.map(r => r.result);
+  query.runResultTransform = (qr) => qr.rows.map((r) => r.result);
   return query;
 };
 
-
 /* === truncate === */
 
-type TruncateIdentityOpts = 'CONTINUE IDENTITY' | 'RESTART IDENTITY';
-type TruncateForeignKeyOpts = 'RESTRICT' | 'CASCADE';
+type TruncateIdentityOpts = "CONTINUE IDENTITY" | "RESTART IDENTITY";
+type TruncateForeignKeyOpts = "RESTRICT" | "CASCADE";
 
 interface TruncateSignatures {
   (table: Table | Table[]): SQLFragment<undefined>;
   (table: Table | Table[], optId: TruncateIdentityOpts): SQLFragment<undefined>;
-  (table: Table | Table[], optFK: TruncateForeignKeyOpts): SQLFragment<undefined>;
-  (table: Table | Table[], optId: TruncateIdentityOpts, optFK: TruncateForeignKeyOpts): SQLFragment<undefined>;
+  (
+    table: Table | Table[],
+    optFK: TruncateForeignKeyOpts
+  ): SQLFragment<undefined>;
+  (
+    table: Table | Table[],
+    optId: TruncateIdentityOpts,
+    optFK: TruncateForeignKeyOpts
+  ): SQLFragment<undefined>;
 }
 
 /**
  * Generate a `TRUNCATE` query `SQLFragment`.
  * @param table The table (or array thereof) to truncate
- * @param opts Options: 'CONTINUE IDENTITY'/'RESTART IDENTITY' and/or 
+ * @param opts Options: 'CONTINUE IDENTITY'/'RESTART IDENTITY' and/or
  * 'RESTRICT'/'CASCADE'
  */
 export const truncate: TruncateSignatures = function (
   table: Table | Table[],
   ...opts: string[]
 ): SQLFragment<undefined> {
-
   if (!Array.isArray(table)) table = [table];
-  const
-    tables = mapWithSeparator(table, sql`, `, t => t),
-    query = sql<SQL, undefined>`TRUNCATE ${tables}${raw((opts.length ? ' ' : '') + opts.join(' '))}`;
+  const tables = mapWithSeparator(table, sql`, `, (t) => t),
+    query = sql<SQL, undefined>`TRUNCATE ${tables}${raw(
+      (opts.length ? " " : "") + opts.join(" ")
+    )}`;
 
   return query;
 };
-
 
 /* === select === */
 
 interface OrderSpecForTable<T extends Table> {
   by: SQLForTable<T>;
-  direction: 'ASC' | 'DESC';
-  nulls?: 'FIRST' | 'LAST';
+  direction: "ASC" | "DESC";
+  nulls?: "FIRST" | "LAST";
 }
 
-type Unprefixed<S extends string> = S extends `${infer _}.${infer Rest}` ? Rest : S;
+type Unprefixed<S extends string> = S extends `${infer _}.${infer Rest}`
+  ? Rest
+  : S;
 
 export interface SelectLockingOptions<A extends string> {
-  for: 'UPDATE' | 'NO KEY UPDATE' | 'SHARE' | 'KEY SHARE';
+  for: "UPDATE" | "NO KEY UPDATE" | "SHARE" | "KEY SHARE";
   of?: Unprefixed<Table> | A | (Unprefixed<Table> | A)[];
-  wait?: 'NOWAIT' | 'SKIP LOCKED';
+  wait?: "NOWAIT" | "SKIP LOCKED";
 }
 
 export interface SelectOptionsForTable<
@@ -400,51 +498,65 @@ export interface SelectOptionsForTable<
   C extends ColumnsOption<T>,
   L extends LateralOption<C, E>,
   E extends ExtrasOption<T>,
-  A extends string,
+  A extends string
 > {
-  distinct?: boolean | ColumnForTable<T> | ColumnForTable<T>[] | SQLFragment<any>;
+  distinct?:
+    | boolean
+    | ColumnForTable<T>
+    | ColumnForTable<T>[]
+    | SQLFragment<any>;
   order?: OrderSpecForTable<T> | OrderSpecForTable<T>[];
   limit?: number;
   offset?: number;
   withTies?: boolean;
   columns?: C;
+  column?: ColumnForTable<T>;
+  array?: ColumnForTable<T>;
   extras?: E;
+  extra?: SQLFragment<any>;
   groupBy?: ColumnForTable<T> | ColumnForTable<T>[] | SQLFragment<any>;
   having?: WhereableForTable<T> | SQLFragment<any>;
   lateral?: L;
   alias?: A;
   lock?: SelectLockingOptions<NoInfer<A>> | SelectLockingOptions<NoInfer<A>>[];
-};
+}
 
 type SelectReturnTypeForTable<
   T extends Table,
   C extends ColumnsOption<T>,
   L extends LateralOption<C, E>,
-  E extends ExtrasOption<T>,
-> =
-  (undefined extends L ? ReturningTypeForTable<T, C, E> :
-    L extends SQLFragmentMap ? ReturningTypeForTable<T, C, E> & LateralResult<L> :
-    L extends SQLFragment<any> ? RunResultForSQLFragment<L> :
-    never);
+  E extends ExtrasOption<T>
+> = undefined extends L
+  ? ReturningTypeForTable<T, C, E>
+  : L extends SQLFragmentMap
+  ? ReturningTypeForTable<T, C, E> & LateralResult<L>
+  : L extends SQLFragment<any>
+  ? RunResultForSQLFragment<L>
+  : never;
 
-export enum SelectResultMode { Many, One, ExactlyOne, Numeric }
+export enum SelectResultMode {
+  Many,
+  One,
+  ExactlyOne,
+  Numeric,
+}
 
 export type FullSelectReturnTypeForTable<
   T extends Table,
   C extends ColumnsOption<T>,
   L extends LateralOption<C, E>,
   E extends ExtrasOption<T>,
-  M extends SelectResultMode,
-> =
-  {
-    [SelectResultMode.Many]: SelectReturnTypeForTable<T, C, L, E>[];
-    [SelectResultMode.ExactlyOne]: SelectReturnTypeForTable<T, C, L, E>;
-    [SelectResultMode.One]: SelectReturnTypeForTable<T, C, L, E> | undefined;
-    [SelectResultMode.Numeric]: number;
-  }[M];
+  M extends SelectResultMode
+> = {
+  [SelectResultMode.Many]: SelectReturnTypeForTable<T, C, L, E>[];
+  [SelectResultMode.ExactlyOne]: SelectReturnTypeForTable<T, C, L, E>;
+  [SelectResultMode.One]: SelectReturnTypeForTable<T, C, L, E> | undefined;
+  [SelectResultMode.Numeric]: number;
+}[M];
 
 export interface SelectSignatures {
-  <T extends Table,
+  <
+    T extends Table,
     C extends ColumnsOption<T>,
     L extends LateralOption<C, E>,
     E extends ExtrasOption<T>,
@@ -455,7 +567,7 @@ export interface SelectSignatures {
     where: WhereableForTable<T> | SQLFragment<any> | AllType,
     options?: SelectOptionsForTable<T, C, L, E, A>,
     mode?: M,
-    aggregate?: string,
+    aggregate?: string
   ): SQLFragment<FullSelectReturnTypeForTable<T, C, L, E, M>>;
 }
 
@@ -464,22 +576,25 @@ export class NotExactlyOneError extends Error {
   query: SQLFragment;
   constructor(query: SQLFragment, ...params: any[]) {
     super(...params);
-    if (Error.captureStackTrace) Error.captureStackTrace(this, NotExactlyOneError);  // V8 only
-    this.name = 'NotExactlyOneError';
-    this.query = query;  // custom property
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NotExactlyOneError);
+    } // V8 only
+    this.name = "NotExactlyOneError";
+    this.query = query; // custom property
   }
 }
 
 /**
- * Generate a `SELECT` query `SQLFragment`. This can be nested with other 
+ * Generate a `SELECT` query `SQLFragment`. This can be nested with other
  * `select`/`selectOne`/`count` queries using the `lateral` option.
  * @param table The table to select from
  * @param where A `Whereable` or `SQLFragment` defining the rows to be selected,
  * or `all`
- * @param options Options object. Keys (all optional) are: 
+ * @param options Options object. Keys (all optional) are:
  * * `columns` — an array of column names: only these columns will be returned
- * * `order` – an array of `OrderSpec` objects, such as 
- * `{ by: 'column', direction: 'ASC' }`  
+ * * `column` — a single column name for nested queries
+ * * `order` – an array of `OrderSpec` objects, such as
+ * `{ by: 'column', direction: 'ASC' }`
  * * `limit` and `offset` – numbers: apply this limit and offset to the query
  * * `lateral` — either an object mapping keys to nested `select`/`selectOne`/
  * `count` queries to be `LATERAL JOIN`ed, or a single `select`/`selectOne`/
@@ -487,93 +602,206 @@ export class NotExactlyOneError extends Error {
  * the containing query
  * * `alias` — table alias (string): required if using `lateral` to join a table
  * to itself
- * * `extras` — an object mapping key(s) to `SQLFragment`s, so that derived 
+ * * `extras` — an object mapping key(s) to `SQLFragment`s, so that derived
+ * * `extra` — a single extra name for nested queries
+ * * `array` — a single column name to be concatenated with array_agg in nested queries
  * quantities can be included in the JSON result
  * @param mode (Used internally by `selectOne` and `count`)
  */
 export const select: SelectSignatures = function (
   table: Table,
   where: Whereable | SQLFragment<any> | AllType = all,
-  options: SelectOptionsForTable<Table, ColumnsOption<Table>, LateralOption<ColumnsOption<Table>, ExtrasOption<Table>>, ExtrasOption<Table>, any> = {},
+  options: SelectOptionsForTable<
+    Table,
+    ColumnsOption<Table>,
+    LateralOption<ColumnsOption<Table>, ExtrasOption<Table>>,
+    ExtrasOption<Table>,
+    any
+  > = {},
   mode: SelectResultMode = SelectResultMode.Many,
-  aggregate: string = 'count',
+  aggregate: string = "count"
 ) {
-
-  const
-    limit1 = mode === SelectResultMode.One || mode === SelectResultMode.ExactlyOne,
+  const limit1 =
+      mode === SelectResultMode.One || mode === SelectResultMode.ExactlyOne,
     allOptions = limit1 ? { ...options, limit: 1 } : options,
     alias = allOptions.alias || table,
-    { distinct, groupBy, having, lateral, columns, extras } = allOptions,
-    lock = allOptions.lock === undefined || Array.isArray(allOptions.lock) ? allOptions.lock : [allOptions.lock],
-    order = allOptions.order === undefined || Array.isArray(allOptions.order) ? allOptions.order : [allOptions.order],
+    {
+      distinct,
+      groupBy,
+      having,
+      lateral,
+      columns,
+      column,
+      array,
+      extras,
+      extra,
+    } = allOptions,
+    lock =
+      allOptions.lock === undefined || Array.isArray(allOptions.lock)
+        ? allOptions.lock
+        : [allOptions.lock],
+    order =
+      allOptions.order === undefined || Array.isArray(allOptions.order)
+        ? allOptions.order
+        : [allOptions.order],
     tableAliasSQL = alias === table ? [] : sql<string>` AS ${alias}`,
-    distinctSQL = !distinct ? [] : sql` DISTINCT${distinct instanceof SQLFragment || typeof distinct === 'string' ? sql` ON (${distinct})` :
-      Array.isArray(distinct) ? sql` ON (${cols(distinct)})` : []}`,
-    colsSQL = lateral instanceof SQLFragment ? [] :
-      mode === SelectResultMode.Numeric ?
-        (columns ? sql`${raw(aggregate)}(${cols(columns)})` : sql`${raw(aggregate)}(${alias}.*)`) :
-        SQLForColumnsOfTable(columns, alias as Table),
-    colsExtraSQL = lateral instanceof SQLFragment || mode === SelectResultMode.Numeric ? [] : SQLForExtras(extras),
-    colsLateralSQL = lateral === undefined || mode === SelectResultMode.Numeric ? [] :
-      lateral instanceof SQLFragment ? sql`"lateral_passthru".result` :
-        sql` || jsonb_build_object(${mapWithSeparator(
-          Object.keys(lateral).sort(), sql`, `, k => sql`${param(k)}::text, "lateral_${raw(k)}".result`)})`,
+    distinctSQL = !distinct
+      ? []
+      : sql` DISTINCT${
+          distinct instanceof SQLFragment || typeof distinct === "string"
+            ? sql` ON (${distinct})`
+            : Array.isArray(distinct)
+            ? sql` ON (${cols(distinct)})`
+            : []
+        }`,
+    colsSQL =
+      lateral instanceof SQLFragment || extra
+        ? []
+        : mode === SelectResultMode.Numeric
+        ? columns
+          ? sql`${raw(aggregate)}(${cols(columns)})`
+          : sql`${raw(aggregate)}(${alias}.*)`
+        : array
+        ? sql`array_agg(${array})`
+        : column
+        ? sql`${column}`
+        : SQLForColumnsOfTable(columns, alias as Table),
+    colsExtraSQL =
+      lateral instanceof SQLFragment || mode === SelectResultMode.Numeric
+        ? []
+        : extra
+        ? sql`${extra}`
+        : SQLForExtras(extras),
+    colsLateralSQL =
+      lateral === undefined || mode === SelectResultMode.Numeric
+        ? []
+        : lateral instanceof SQLFragment
+        ? sql`"lateral_passthru".result`
+        : sql` || jsonb_build_object(${mapWithSeparator(
+            Object.keys(lateral).sort(),
+            sql`, `,
+            (k) => sql`${param(k)}::text, "lateral_${raw(k)}".result`
+          )})`,
     allColsSQL = sql`${colsSQL}${colsExtraSQL}${colsLateralSQL}`,
     whereSQL = where === all ? [] : sql` WHERE ${where}`,
-    groupBySQL = !groupBy ? [] : sql` GROUP BY ${groupBy instanceof SQLFragment || typeof groupBy === 'string' ? groupBy : cols(groupBy)}`,
+    groupBySQL = !groupBy
+      ? []
+      : sql` GROUP BY ${
+          groupBy instanceof SQLFragment || typeof groupBy === "string"
+            ? groupBy
+            : cols(groupBy)
+        }`,
     havingSQL = !having ? [] : sql` HAVING ${having}`,
-    orderSQL = order === undefined ? [] :
-      sql` ORDER BY ${mapWithSeparator(order as OrderSpecForTable<Table>[], sql`, `, o => {  // `as` clause is required when TS not strict
-        if (!['ASC', 'DESC'].includes(o.direction)) throw new Error(`Direction must be ASC/DESC, not '${o.direction}'`);
-        if (o.nulls && !['FIRST', 'LAST'].includes(o.nulls)) throw new Error(`Nulls must be FIRST/LAST/undefined, not '${o.nulls}'`);
-        return sql`${o.by} ${raw(o.direction)}${o.nulls ? sql` NULLS ${raw(o.nulls)}` : []}`;
-      })}`,
-    limitSQL = allOptions.limit === undefined ? [] :
-      allOptions.withTies ? sql` FETCH FIRST ${param(allOptions.limit)} ROWS WITH TIES` :
-        sql` LIMIT ${param(allOptions.limit)}`,  // compatibility with pg pre-10.5; and fewer bytes!
-    offsetSQL = allOptions.offset === undefined ? [] : sql` OFFSET ${param(allOptions.offset)}`,  // pg is lax about OFFSET following FETCH, and we exploit that
-    lockSQL = lock === undefined ? [] : (lock as SelectLockingOptions<string>[]).map(lock => {  // `as` clause is required when TS not strict
-      const
-        ofTables = lock.of === undefined || Array.isArray(lock.of) ? lock.of : [lock.of],
-        ofClause = ofTables === undefined ? [] : sql` OF ${mapWithSeparator(ofTables as Table[], sql`, `, t => t)}`;  // `as` clause is required when TS not strict
-      return sql` FOR ${raw(lock.for)}${ofClause}${lock.wait ? sql` ${raw(lock.wait)}` : []}`;
-    }),
-    lateralSQL = lateral === undefined ? [] :
-      lateral instanceof SQLFragment ? (() => {
-        lateral.parentTable = alias;
-        return sql` LEFT JOIN LATERAL (${lateral}) AS "lateral_passthru" ON true`;
-      })() :
-        Object.keys(lateral).sort().map(k => {
-          const subQ = lateral[k];
-          subQ.parentTable = alias;  // enables `parent('column')` in subquery's Whereables
-          return sql` LEFT JOIN LATERAL (${subQ}) AS "lateral_${raw(k)}" ON true`;
-        });
+    orderSQL =
+      order === undefined
+        ? []
+        : sql` ORDER BY ${mapWithSeparator(
+            order as OrderSpecForTable<Table>[],
+            sql`, `,
+            (o) => {
+              // `as` clause is required when TS not strict
+              if (!["ASC", "DESC"].includes(o.direction)) {
+                throw new Error(
+                  `Direction must be ASC/DESC, not '${o.direction}'`
+                );
+              }
+              if (o.nulls && !["FIRST", "LAST"].includes(o.nulls)) {
+                throw new Error(
+                  `Nulls must be FIRST/LAST/undefined, not '${o.nulls}'`
+                );
+              }
+              return sql`${o.by} ${raw(o.direction)}${
+                o.nulls ? sql` NULLS ${raw(o.nulls)}` : []
+              }`;
+            }
+          )}`,
+    limitSQL =
+      allOptions.limit === undefined
+        ? []
+        : allOptions.withTies
+        ? sql` FETCH FIRST ${param(allOptions.limit)} ROWS WITH TIES`
+        : sql` LIMIT ${param(allOptions.limit)}`, // compatibility with pg pre-10.5; and fewer bytes!
+    offsetSQL =
+      allOptions.offset === undefined
+        ? []
+        : sql` OFFSET ${param(allOptions.offset)}`, // pg is lax about OFFSET following FETCH, and we exploit that
+    lockSQL =
+      lock === undefined
+        ? []
+        : (lock as SelectLockingOptions<string>[]).map((lock) => {
+            // `as` clause is required when TS not strict
+            const ofTables =
+                lock.of === undefined || Array.isArray(lock.of)
+                  ? lock.of
+                  : [lock.of],
+              ofClause =
+                ofTables === undefined
+                  ? []
+                  : sql` OF ${mapWithSeparator(
+                      ofTables as Table[],
+                      sql`, `,
+                      (t) => t
+                    )}`; // `as` clause is required when TS not strict
+            return sql` FOR ${raw(lock.for)}${ofClause}${
+              lock.wait ? sql` ${raw(lock.wait)}` : []
+            }`;
+          }),
+    lateralSQL =
+      lateral === undefined
+        ? []
+        : lateral instanceof SQLFragment
+        ? (() => {
+            lateral.parentTable = alias;
+            return sql` LEFT JOIN LATERAL (${lateral}) AS "lateral_passthru" ON true`;
+          })()
+        : Object.keys(lateral)
+            .sort()
+            .map((k) => {
+              const subQ = lateral[k];
+              subQ.parentTable = alias; // enables `parent('column')` in subquery's Whereables
+              return sql` LEFT JOIN LATERAL (${subQ}) AS "lateral_${raw(
+                k
+              )}" ON true`;
+            });
 
-  const
-    rowsQuery = sql<SQL, any>`SELECT${distinctSQL} ${allColsSQL} AS result FROM ${table}${tableAliasSQL}${lateralSQL}${whereSQL}${groupBySQL}${havingSQL}${orderSQL}${limitSQL}${offsetSQL}${lockSQL}`,
-    query = mode !== SelectResultMode.Many ? rowsQuery :
-      // we need the aggregate to sit in a sub-SELECT in order to keep ORDER and LIMIT working as usual
-      sql<SQL, any>`SELECT coalesce(jsonb_agg(result), '[]') AS result FROM (${rowsQuery}) AS ${raw(`"sq_${alias}"`)}`;
+  const rowsQuery = sql<
+      SQL,
+      any
+    >`SELECT${distinctSQL} ${allColsSQL} AS result FROM ${table}${tableAliasSQL}${lateralSQL}${whereSQL}${groupBySQL}${havingSQL}${orderSQL}${limitSQL}${offsetSQL}${lockSQL}`,
+    query =
+      mode !== SelectResultMode.Many
+        ? rowsQuery
+        : column || array
+        ? sql<SQL, any>`${rowsQuery}`
+        : // we need the aggregate to sit in a sub-SELECT in order to keep ORDER and LIMIT working as usual
+          sql<
+            SQL,
+            any
+          >`SELECT coalesce(jsonb_agg(result), '[]') AS result FROM (${rowsQuery}) AS ${raw(
+            `"sq_${alias}"`
+          )}`;
 
   query.runResultTransform =
-
-    mode === SelectResultMode.Numeric ?
-      // note: pg deliberately returns strings for int8 in case 64-bit numbers overflow
-      // (see https://github.com/brianc/node-pg-types#use), but we assume our counts aren't that big
-      (qr) => Number(qr.rows[0].result) :
-
-      mode === SelectResultMode.ExactlyOne ?
-        (qr) => {
+    mode === SelectResultMode.Numeric
+      ? // note: pg deliberately returns strings for int8 in case 64-bit numbers overflow
+        // (see https://github.com/brianc/node-pg-types#use), but we assume our counts aren't that big
+        (qr) => Number(qr.rows[0].result)
+      : mode === SelectResultMode.ExactlyOne
+      ? (qr) => {
           const result = qr.rows[0]?.result;
-          if (result === undefined) throw new NotExactlyOneError(query, 'One result expected but none returned (hint: check `.query.compile()` on this Error)');
+          if (result === undefined) {
+            throw new NotExactlyOneError(
+              query,
+              "One result expected but none returned (hint: check `.query.compile()` on this Error)"
+            );
+          }
           return result;
-        } :
-        // SelectResultMode.One or SelectResultMode.Many
+        }
+      : // SelectResultMode.One or SelectResultMode.Many
         (qr) => qr.rows[0]?.result;
 
   return query;
 };
-
 
 /* === selectOne === */
 
@@ -583,34 +811,39 @@ export interface SelectOneSignatures {
     C extends ColumnsOption<T>,
     L extends LateralOption<C, E>,
     E extends ExtrasOption<T>,
-    A extends string,
+    A extends string
   >(
     table: T,
     where: WhereableForTable<T> | SQLFragment<any> | AllType,
-    options?: SelectOptionsForTable<T, C, L, E, A>,
-  ): SQLFragment<FullSelectReturnTypeForTable<T, C, L, E, SelectResultMode.One>>;
+    options?: SelectOptionsForTable<T, C, L, E, A>
+  ): SQLFragment<
+    FullSelectReturnTypeForTable<T, C, L, E, SelectResultMode.One>
+  >;
 }
 
 /**
- * Generate a `SELECT` query `SQLFragment` that returns only a single result (or 
- * undefined). A `LIMIT 1` clause is added automatically. This can be nested with 
+ * Generate a `SELECT` query `SQLFragment` that returns only a single result (or
+ * undefined). A `LIMIT 1` clause is added automatically. This can be nested with
  * other `select`/`selectOne`/`count` queries using the `lateral` option.
  * @param table The table to select from
  * @param where A `Whereable` or `SQLFragment` defining the rows to be selected,
  * or `all`
  * @param options Options object. See documentation for `select` for details.
  */
-export const selectOne: SelectOneSignatures = function (table, where, options = {}) {
-  // you might argue that 'selectOne' offers little that you can't get with 
-  // destructuring assignment and plain 'select' 
+export const selectOne: SelectOneSignatures = function (
+  table,
+  where,
+  options = {}
+) {
+  // you might argue that 'selectOne' offers little that you can't get with
+  // destructuring assignment and plain 'select'
   // -- e.g.let[x] = async select(...).run(pool); -- but something worth having
-  // is '| undefined' in the return signature, because the result of indexing 
+  // is '| undefined' in the return signature, because the result of indexing
   // never includes undefined (until 4.1 and --noUncheckedIndexedAccess)
   // (see https://github.com/Microsoft/TypeScript/issues/13778)
 
   return select(table, where, options, SelectResultMode.One);
 };
-
 
 /* === selectExactlyOne === */
 
@@ -620,18 +853,20 @@ export interface SelectExactlyOneSignatures {
     C extends ColumnsOption<T>,
     L extends LateralOption<C, E>,
     E extends ExtrasOption<T>,
-    A extends string,
+    A extends string
   >(
     table: T,
     where: WhereableForTable<T> | SQLFragment<any> | AllType,
-    options?: SelectOptionsForTable<T, C, L, E, A>,
-  ): SQLFragment<FullSelectReturnTypeForTable<T, C, L, E, SelectResultMode.ExactlyOne>>;
+    options?: SelectOptionsForTable<T, C, L, E, A>
+  ): SQLFragment<
+    FullSelectReturnTypeForTable<T, C, L, E, SelectResultMode.ExactlyOne>
+  >;
 }
 
 /**
- * Generate a `SELECT` query `SQLFragment` that returns a single result or 
- * throws an error. A `LIMIT 1` clause is added automatically. This can be 
- * nested with other `select`/`selectOne`/`count` queries using the `lateral` 
+ * Generate a `SELECT` query `SQLFragment` that returns a single result or
+ * throws an error. A `LIMIT 1` clause is added automatically. This can be
+ * nested with other `select`/`selectOne`/`count` queries using the `lateral`
  * option.
  * @param table The table to select from
  * @param where A `Whereable` or `SQLFragment` defining the rows to be selected,
@@ -639,10 +874,13 @@ export interface SelectExactlyOneSignatures {
  * @param options Options object. See documentation for `select` for details.
  */
 
-export const selectExactlyOne: SelectExactlyOneSignatures = function (table, where, options = {}) {
+export const selectExactlyOne: SelectExactlyOneSignatures = function (
+  table,
+  where,
+  options = {}
+) {
   return select(table, where, options, SelectResultMode.ExactlyOne);
 };
-
 
 /* === count, sum, avg === */
 
@@ -652,36 +890,44 @@ export interface NumericAggregateSignatures {
     C extends ColumnsOption<T>,
     L extends LateralOption<C, E>,
     E extends ExtrasOption<T>,
-    A extends string,
+    A extends string
   >(
     table: T,
     where: WhereableForTable<T> | SQLFragment<any> | AllType,
-    options?: SelectOptionsForTable<T, C, L, E, A>,
+    options?: SelectOptionsForTable<T, C, L, E, A>
   ): SQLFragment<number>;
 }
 
 /**
- * Generate a `SELECT` query `SQLFragment` that returns a count. This can be 
+ * Generate a `SELECT` query `SQLFragment` that returns a count. This can be
  * nested in other `select`/`selectOne` queries using their `lateral` option.
  * @param table The table to count from
- * @param where A `Whereable` or `SQLFragment` defining the rows to be counted, 
+ * @param where A `Whereable` or `SQLFragment` defining the rows to be counted,
  * or `all`
  * @param options Options object. Useful keys may be: `columns`, `alias`.
  */
-export const count: NumericAggregateSignatures = function (table, where, options?) {
+export const count: NumericAggregateSignatures = function (
+  table,
+  where,
+  options?
+) {
   return select(table, where, options, SelectResultMode.Numeric);
 };
 
 /**
- * Generate a `SELECT` query `SQLFragment` that returns a sum. This can be 
+ * Generate a `SELECT` query `SQLFragment` that returns a sum. This can be
  * nested in other `select`/`selectOne` queries using their `lateral` option.
  * @param table The table to aggregate from
  * @param where A `Whereable` or `SQLFragment` defining the rows to be
  * aggregated, or `all`
  * @param options Options object. Useful keys may be: `columns`, `alias`.
  */
-export const sum: NumericAggregateSignatures = function (table, where, options?) {
-  return select(table, where, options, SelectResultMode.Numeric, 'sum');
+export const sum: NumericAggregateSignatures = function (
+  table,
+  where,
+  options?
+) {
+  return select(table, where, options, SelectResultMode.Numeric, "sum");
 };
 
 /**
@@ -693,8 +939,12 @@ export const sum: NumericAggregateSignatures = function (table, where, options?)
  * aggregated, or `all`
  * @param options Options object. Useful keys may be: `columns`, `alias`.
  */
-export const avg: NumericAggregateSignatures = function (table, where, options?) {
-  return select(table, where, options, SelectResultMode.Numeric, 'avg');
+export const avg: NumericAggregateSignatures = function (
+  table,
+  where,
+  options?
+) {
+  return select(table, where, options, SelectResultMode.Numeric, "avg");
 };
 
 /**
@@ -702,12 +952,16 @@ export const avg: NumericAggregateSignatures = function (table, where, options?)
  * aggregate function. This can be nested in other `select`/`selectOne` queries
  * using their `lateral` option.
  * @param table The table to aggregate from
- * @param where A `Whereable` or `SQLFragment` defining the rows to be 
+ * @param where A `Whereable` or `SQLFragment` defining the rows to be
  * aggregated, or `all`
  * @param options Options object. Useful keys may be: `columns`, `alias`.
  */
-export const min: NumericAggregateSignatures = function (table, where, options?) {
-  return select(table, where, options, SelectResultMode.Numeric, 'min');
+export const min: NumericAggregateSignatures = function (
+  table,
+  where,
+  options?
+) {
+  return select(table, where, options, SelectResultMode.Numeric, "min");
 };
 
 /**
@@ -719,6 +973,21 @@ export const min: NumericAggregateSignatures = function (table, where, options?)
  * aggregated, or `all`
  * @param options Options object. Useful keys may be: `columns`, `alias`.
  */
-export const max: NumericAggregateSignatures = function (table, where, options?) {
-  return select(table, where, options, SelectResultMode.Numeric, 'max');
+export const max: NumericAggregateSignatures = function (
+  table,
+  where,
+  options?
+) {
+  return select(table, where, options, SelectResultMode.Numeric, "max");
+};
+
+/**
+ * Transforms an `SQLFragment` into a sub-query to obtain a value instead of an object
+ * @param frag The `SQLFragment` to be transformed
+ * @returns The value of type T
+ */
+export const nested: <T>(frag: SQLFragment<any>) => T = function <T>(
+  frag: SQLFragment<any>
+): T {
+  return sql`(${frag})` as T;
 };


### PR DESCRIPTION
Adds 3 more properties in options allowing to retrieve a value instead of an object : 
- column
- extra
- array

Adds a new shortcut allowing subqueries in Whereable, Insertable and Updatable :
- nested<expected_type>(frag: SQLFragment<any>) : expected_type

Tests and usage examples are available [here](https://github.com/synicko/zapatos-tests)