### PR TITLE
Add order to column generation to improve schema consistency

### DIFF
--- a/src/generate/tables.ts
+++ b/src/generate/tables.ts
@@ -67,7 +67,8 @@ const columnsForRelation = async (rel: Relation, schemaName: string, queryFn: (q
         LEFT JOIN pg_catalog.pg_type t1 ON t1.oid = a.atttypid
         LEFT JOIN pg_catalog.pg_type t2 ON t2.oid = t1.typbasetype
         LEFT JOIN pg_catalog.pg_description d ON d.objoid = c.oid AND d.objsubid = a.attnum
-        WHERE c.relkind = 'm' AND a.attnum >= 1 AND c.relname = $1 AND n.nspname = $2`
+        WHERE c.relkind = 'm' AND a.attnum >= 1 AND c.relname = $1 AND n.nspname = $2
+        ORDER BY "column"`
         : `
         SELECT
           column_name AS "column"
@@ -82,7 +83,8 @@ const columnsForRelation = async (rel: Relation, schemaName: string, queryFn: (q
         LEFT JOIN pg_catalog.pg_namespace ns ON ns.nspname = c.table_schema
         LEFT JOIN pg_catalog.pg_class cl ON cl.relkind = 'r' AND cl.relname = c.table_name AND cl.relnamespace = ns.oid
         LEFT JOIN pg_catalog.pg_description d ON d.objoid = cl.oid AND d.objsubid = c.ordinal_position
-        WHERE c.table_name = $1 AND c.table_schema = $2`,
+        WHERE c.table_name = $1 AND c.table_schema = $2
+        ORDER BY "column"`,
     values: [rel.name, schemaName],
   });
 


### PR DESCRIPTION
Hi jawj! Love the tool and was hoping to contribute a little.

A few of the dev's I'm working with were hoping that the schema could be committed to our source code. The advantage would be that merge requests that have made database changes are really obvious. It also highlights if the developers local database may differ from what they expect if they regenerate and get a different schema. Git would point out that it has changed.

At least that was the hope, until we noticed hat schema's don't generate consistently. I think I've mostly traced it down to these two lines not ordering their responses.

Simple fix! Not that I can guarantee that this will fix all schema inconsistencies... but we're moving towards stability. If we find other points of inconsistency I can make another pull request.

Thanks again for your work.