### PR TITLE
Add const to exact comparisons

### DIFF
--- a/src/db/conditions.ts
+++ b/src/db/conditions.ts
@@ -29,11 +29,11 @@ export const isNotFalse = sql<SQL, boolean>`${self} IS NOT FALSE`;
 export const isUnknown = sql<SQL, boolean>`${self} IS UNKNOWN`;
 export const isNotUnknown = sql<SQL, boolean>`${self} IS NOT UNKNOWN`;
 
-export const isDistinctFrom = <T>(a: T) => sql<SQL, boolean, T>`${self} IS DISTINCT FROM ${conditionalParam(a)}`;
-export const isNotDistinctFrom = <T>(a: T) => sql<SQL, boolean, T>`${self} IS NOT DISTINCT FROM ${conditionalParam(a)}`;
+export const isDistinctFrom = <const T>(a: T) => sql<SQL, boolean, T>`${self} IS DISTINCT FROM ${conditionalParam(a)}`;
+export const isNotDistinctFrom = <const T>(a: T) => sql<SQL, boolean, T>`${self} IS NOT DISTINCT FROM ${conditionalParam(a)}`;
 
-export const eq = <T>(a: T) => sql<SQL, boolean | null, T>`${self} = ${conditionalParam(a)}`;
-export const ne = <T>(a: T) => sql<SQL, boolean | null, T>`${self} <> ${conditionalParam(a)}`;
+export const eq = <const T>(a: T) => sql<SQL, boolean | null, T>`${self} = ${conditionalParam(a)}`;
+export const ne = <const T>(a: T) => sql<SQL, boolean | null, T>`${self} <> ${conditionalParam(a)}`;
 export const gt = <T>(a: T) => sql<SQL, boolean | null, T>`${self} > ${conditionalParam(a)}`;
 export const gte = <T>(a: T) => sql<SQL, boolean | null, T>`${self} >= ${conditionalParam(a)}`;
 export const lt = <T>(a: T) => sql<SQL, boolean | null, T>`${self} < ${conditionalParam(a)}`;
@@ -55,8 +55,8 @@ export const reImatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`
 export const notReMatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} !~ ${conditionalParam(a)}`;
 export const notReImatch = <T extends string>(a: T) => sql<SQL, boolean | null, T>`${self} !~* ${conditionalParam(a)}`;
 
-export const isIn = <T>(a: readonly T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} IN (${vals(a)})` : sql`false`;
-export const isNotIn = <T>(a: readonly T[]) => a.length > 0 ? sql<SQL, boolean | null, T>`${self} NOT IN (${vals(a)})` : sql`true`;
+export const isIn = <const T extends readonly unknown[]>(a: T) => a.length > 0 ? sql<SQL, boolean | null, T[number]>`${self} IN (${vals(a)})` : sql`false`;
+export const isNotIn = <const T extends readonly unknown[]>(a: T) => a.length > 0 ? sql<SQL, boolean | null, T[number]>`${self} NOT IN (${vals(a)})` : sql`true`;
 
 export const or = <T>(...conditions: (SQLFragment<any, T> | Whereable)[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` OR `, c => c)})`;
 export const and = <T>(...conditions: (SQLFragment<any, T> | Whereable)[]) => sql<SQL, boolean | null, T>`(${mapWithSeparator(conditions, sql` AND `, c => c)})`;


### PR DESCRIPTION
This improves postgres enum support by making `as const` not needed in conditions when creating conditions for columns with enum types.

This typescript feature requires typescript 5.0. This might be problematic because the peer dependency is `"typescript": ">=4.1"`.

This is an example of the problem this PR is trying to fix.
<details><summary>Schema</summary>

```ts
declare module 'zapatos/schema' {
  export type enum_profile_avail_check_status = 'Avail' | 'Unavail' | 'Waiting';

  export namespace profile_avail_check {
    export type Table = 'profile_avail_check';
    export interface Whereable {
      /**
       * **profile_avail_check.status**
       * - `enum_profile_avail_check_status` in database
       * - `NOT NULL`, default: `'Waiting'::enum_profile_avail_check_status`
       */
      status?:
        | enum_profile_avail_check_status
        | db.Parameter<enum_profile_avail_check_status>
        | db.SQLFragment
        | db.ParentColumn
        | db.SQLFragment<
            any,
            | enum_profile_avail_check_status
            | db.Parameter<enum_profile_avail_check_status>
            | db.SQLFragment
            | db.ParentColumn
          >;
    }
  }
}
```

</details>

Before this change, the following code has a typescript error:
```ts
db.select('profile_avail_check', {
  status: db.conditions.ne('Waiting'),
});
```
The reason it has a typescript error is because the type of `db.conditions.ne('Waiting')` is inferred to be `SQLFragment<boolean | null, string>`, which is not a subtype of `db.SQLFragment<any, enum_profile_avail_check_status>`. A workaround is to instead do
```ts
db.select('profile_avail_check', {
  status: db.conditions.ne('Waiting' as const),
});
```
With the workaround, `db.conditions.ne('Waiting')` is inferred to be `SQLFragment<boolean | null, 'Waiting'>` which is a subtype of `db.SQLFragment<any, enum_profile_avail_check_status>`. However, it can be annoying to remember this workaround.

This PR removes the need for the workaround by telling typescript to infer the narrowest type possible for the parameter.