### PR TITLE
fix sticky parent tables

### DIFF
--- a/src/db/core.ts
+++ b/src/db/core.ts
@@ -245,6 +245,28 @@ export class SQLFragment<RunResult = pg.QueryResult['rows'], Constraint = never>
   constructor(protected literals: string[], protected expressions: SQL[]) { }
 
   /**
+   * Performs a shallow copy of this SQLFragment, optionally overriding some of its properties.
+   * @param override The properties to override
+   */
+  copy(override?: {
+    literals?: string[];
+    expressions?: SQL[];
+    parentTable?: string;
+    preparedName?: string;
+    noop?: boolean;
+    noopResult?: any;
+  }): SQLFragment<RunResult, Constraint> {
+    const { literals = this.literals, expressions = this.expressions, ...overrideRest } = override ?? {};
+    const copy = new SQLFragment<RunResult, Constraint>(literals, expressions);
+    return Object.assign(copy, {
+      parentTable: this.parentTable,
+      preparedName: this.preparedName,
+      noop: this.noop,
+      noopResult: this.noopResult
+    }, overrideRest);
+  }
+
+  /**
    * Instruct Postgres to treat this as a prepared statement: see
    * https://node-postgres.com/features/queries#prepared-statements
    * @param name A name for the prepared query. If not specified, it takes the

--- a/src/db/shortcuts.ts
+++ b/src/db/shortcuts.ts
@@ -542,12 +542,11 @@ export const select: SelectSignatures = function (
     }),
     lateralSQL = lateral === undefined ? [] :
       lateral instanceof SQLFragment ? (() => {
-        lateral.parentTable = alias;
-        return sql` LEFT JOIN LATERAL (${lateral}) AS "lateral_passthru" ON true`;
+        return sql` LEFT JOIN LATERAL (${lateral.copy({ parentTable: alias })}) AS "lateral_passthru" ON true`;
       })() :
         Object.keys(lateral).sort().map(k => {
-          const subQ = lateral[k];
-          subQ.parentTable = alias;  // enables `parent('column')` in subquery's Whereables
+          /// enables `parent('column')` in subquery's Whereables
+          const subQ = lateral[k].copy({ parentTable: alias });
           return sql` LEFT JOIN LATERAL (${subQ}) AS "lateral_${raw(k)}" ON true`;
         });
 


### PR DESCRIPTION
Fixes parent tables being sticky when a lateral query is re-used by making a defensive copy of the lateral query.

Fixes https://github.com/jawj/zapatos/issues/167