### PR TITLE
Fix typos in `TimestampString`/`TimestampTzString` comments

### DIFF
--- a/src/db/date.ts
+++ b/src/db/date.ts
@@ -30,13 +30,13 @@ export type TimeTzString = `${TimeString}${TzSuffix}`;
 
 /**
  * An ISO8601-formatted date and time string **with no timezone**, such as
- * `"2021-05-25T14:41.10.249097"`.
+ * `"2021-05-25T14:41:10.249097"`.
  */
 export type TimestampString = `${DateString}T${TimeString}`;
 
 /**
  * An ISO8601-formatted date, time and (numeric) timezone string, such as
- * `"2021-05-25T14:41.10.249097+01:00"`.
+ * `"2021-05-25T14:41:10.249097+01:00"`.
  */
 export type TimestampTzString = `${TimestampString}${TzSuffix}`;
 


### PR DESCRIPTION
Thank you for this great library, I've been using it for years and I really enjoy it. I found two tiny typos in the comments for `TimestampString`/`TimestampTzString` and thought I'd send a PR. Thank you again!